### PR TITLE
Fix market sell inventory check

### DIFF
--- a/src/components/market/MarketUI.tsx
+++ b/src/components/market/MarketUI.tsx
@@ -315,10 +315,12 @@ export const MarketUI: React.FC<{ onClose: (attackInfo?: any) => void }> = ({ on
         case 'equipment': {
           // Aggregate unequipped equipment by name
           const equipmentMap = new Map();
-          (player.inventory || [])
+            (player.inventory || [])
             .filter(item =>
               item.type !== 'scroll' &&
-              !(player.equipment || []).some(eq => eq.id === item.id)
+              !Object.values(player.equipment || {}).some(
+                eq => eq && eq.id === item.id
+              )
             )
             .forEach(item => {
               if (equipmentMap.has(item.name)) {


### PR DESCRIPTION
## Summary
- correctly detect equipped items when listing sell options

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684049a554988333abc7fc084e9e636c