### PR TITLE
Fix unequip typo

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,5 +3,5 @@
 - Save slots need Unique ID's to hopefully fix the issue with only the last used save slot being saved or usable.
 - Market sell function not working as intended/expected. It never shows any items in the player inventory to sell and it should if the player has items in their inventory that are not equipped currently. Needs code audit with intent to hook up this functionality. Markets should have a limited amount of gold to buy items with that resets when the inventory refreshes.
 - Potion crafting seems like it's not implemented completely or properly hooked up. Needs code audit.
-- Equipping an item in inventory to a slot with an item already equipped overwrites the already equipped item effectively deleting it. It should unequipt the already equipped item when equipping a new item to the same slot.
+- Equipping an item in inventory to a slot with an item already equipped overwrites the already equipped item effectively deleting it. It should unequip the already equipped item when equipping a new item to the same slot.
 - Market Attacks seem like they are not triggering when leaving markets, which seems odd given it did work earlier in development. Needs code audit. Expectation, when clicking leave market or when traveling to a new market there is a random chance of triggering a market attack as described in docs/requirements.md


### PR DESCRIPTION
## Summary
- fix 'unequipt' typo in BUGS.md

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840b2b3a13083338254ef2dbc42e1ae