### PR TITLE
Add overrides for deprecated packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,5 +94,9 @@
     "typescript": "^5",
     "wrangler": "^3.102.0"
   },
+  "overrides": {
+    "sourcemap-codec": "npm:@jridgewell/sourcemap-codec@^1.5.0",
+    "rollup-plugin-inject": "npm:@rollup/plugin-inject@^5.0.0"
+  },
   "packageManager": "pnpm@10.0.0-rc.2+sha512.b6e59b96f90ca92449ac2f6dca9b430880448fc97d21f0fa9200e3d5ddb5289ad535255400554f7f3486e2d60058492161aaa9b58828e81f50c096718be9d156"
 }


### PR DESCRIPTION
## Summary
- avoid deprecated packages during npm install

## Testing
- `npm run lint` *(fails: Next.js eslint plugin not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68429f75e0a88333b2fcf8f12883f87d