### PR TITLE
Add hex overlay to battle platform

### DIFF
--- a/src/components/battle/BattleScene.tsx
+++ b/src/components/battle/BattleScene.tsx
@@ -5,6 +5,7 @@ import { Canvas, useFrame } from '@react-three/fiber';
 import { Environment, Stars, Text, OrbitControls } from '@react-three/drei';
 import SpellEffect3D from './effects/SpellEffect3D';
 import WizardModel from './WizardModel';
+import HexGrid from './HexGrid';
 import { Spell, ActiveEffect } from '../../lib/types/spell-types';
 import { CombatState, CombatLogEntry, CombatWizard } from '../../lib/types/combat-types';
 
@@ -190,12 +191,18 @@ const BattleSceneContent: React.FC<BattleSceneProps> = (props) => {
       {/* Battle platform */}
       <mesh position={[0, -0.5, 0]} rotation={[-Math.PI / 2, 0, 0]} scale={1}>
         <circleGeometry args={[5, 32]} />
-        <meshStandardMaterial 
+        <meshStandardMaterial
           color={theme.colors.platform}
           metalness={0.7}
           roughness={0.2}
         />
       </mesh>
+
+      {/* Hexagonal battlefield overlay */}
+      {/* Slightly above the platform to avoid z-fighting */}
+      <group position={[0, -0.49, 0]}>
+        <HexGrid gridRadius={3} radius={1} height={0.2} />
+      </group>
       
       {/* Player wizard */}
       <WizardModel 

--- a/src/components/battle/HexGrid.tsx
+++ b/src/components/battle/HexGrid.tsx
@@ -1,0 +1,66 @@
+import React, { useMemo } from 'react';
+import { useLoader } from '@react-three/fiber';
+import { TextureLoader } from 'three';
+
+type Vec3 = [number, number, number];
+
+interface HexGridProps {
+  radius?: number;
+  gridRadius?: number;
+  height?: number;
+  textureUrl?: string;
+}
+
+interface HexTileProps {
+  position: Vec3;
+  radius: number;
+  height: number;
+  textureUrl?: string;
+}
+
+const HexTile: React.FC<HexTileProps> = ({ position, radius, height, textureUrl }) => {
+  const texture = textureUrl ? useLoader(TextureLoader, textureUrl) : undefined;
+
+  // CylinderGeometry groups: 0 - side, 1 - top, 2 - bottom
+  const materials = useMemo(() => {
+    const side = { color: '#333333' } as const;
+    const top = texture ? { map: texture } : { color: '#666666' };
+    const mat = [side, top, top];
+    return mat;
+  }, [texture]);
+
+  return (
+    <mesh position={position} rotation={[0, 0, 0]}>
+      <cylinderGeometry args={[radius, radius, height, 6]} />
+      {materials.map((props, idx) => (
+        <meshStandardMaterial key={idx} attach={`material-${idx}`} {...props} />
+      ))}
+    </mesh>
+  );
+};
+
+const HexGrid: React.FC<HexGridProps> = ({ radius = 1, gridRadius = 2, height = 0.2, textureUrl }) => {
+  const tiles: Vec3[] = useMemo(() => {
+    const arr: Vec3[] = [];
+    for (let q = -gridRadius; q <= gridRadius; q++) {
+      const r1 = Math.max(-gridRadius, -q - gridRadius);
+      const r2 = Math.min(gridRadius, -q + gridRadius);
+      for (let r = r1; r <= r2; r++) {
+        const x = radius * Math.sqrt(3) * (q + r / 2);
+        const z = radius * 1.5 * r;
+        arr.push([x, 0, z]);
+      }
+    }
+    return arr;
+  }, [gridRadius, radius]);
+
+  return (
+    <group>
+      {tiles.map((pos, idx) => (
+        <HexTile key={idx} position={pos} radius={radius} height={height} textureUrl={textureUrl} />
+      ))}
+    </group>
+  );
+};
+
+export default HexGrid;

--- a/src/components/battle/index.ts
+++ b/src/components/battle/index.ts
@@ -4,4 +4,5 @@
 export { default as BattleArena } from './BattleArena';
 export { default as BattleLog } from './BattleLog';
 export { default as PlayerHand } from './PlayerHand';
-export { default as WizardStats } from './WizardStats'; 
+export { default as WizardStats } from './WizardStats';
+export { default as HexGrid } from './HexGrid';


### PR DESCRIPTION
## Summary
- overlay hex grid on the circular battle platform

## Testing
- `npm test` *(fails: No player data, connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68437783094c83338ef41086a0b66667