### PR TITLE
Resolve merge conflicts for PR #8

### DIFF
--- a/src/components/battle/BattleScene.tsx
+++ b/src/components/battle/BattleScene.tsx
@@ -5,7 +5,7 @@ import { Canvas, useFrame } from '@react-three/fiber';
 import { Environment, Stars, Text, OrbitControls } from '@react-three/drei';
 import SpellEffect3D from './effects/SpellEffect3D';
 import WizardModel from './WizardModel';
-import HexGrid from './HexGrid';
+import HexGrid, { TILE_COLORS } from './HexGrid';
 import { Spell, ActiveEffect } from '../../lib/types/spell-types';
 import { CombatState, CombatLogEntry, CombatWizard } from '../../lib/types/combat-types';
 
@@ -86,6 +86,14 @@ const BattleSceneContent: React.FC<BattleSceneProps> = (props) => {
       }
     }
   };
+
+  const textureMap = {
+    grass: '/tiles/grass.png',
+    stone: '/tiles/stone.png',
+    brick: '/tiles/brick.png',
+    dirt: '/tiles/dirt.png',
+    water: '/tiles/water.png'
+  } as const;
   
   // Process combat log to create visual effects
   useEffect(() => {
@@ -201,7 +209,7 @@ const BattleSceneContent: React.FC<BattleSceneProps> = (props) => {
       {/* Hexagonal battlefield overlay */}
       {/* Slightly above the platform to avoid z-fighting */}
       <group position={[0, -0.49, 0]}>
-        <HexGrid gridRadius={3} radius={1} height={0.2} />
+        <HexGrid gridRadius={3} radius={1} height={0.2} textureMap={textureMap} />
       </group>
       
       {/* Player wizard */}

--- a/src/components/battle/HexGrid.tsx
+++ b/src/components/battle/HexGrid.tsx
@@ -1,33 +1,46 @@
 import React, { useMemo } from 'react';
 import { useLoader } from '@react-three/fiber';
 import { TextureLoader } from 'three';
+import { Edges } from '@react-three/drei';
 
 type Vec3 = [number, number, number];
+
+type TileType = 'grass' | 'stone' | 'brick' | 'dirt' | 'water';
+
+export const TILE_COLORS: Record<TileType, string> = {
+  grass: '#3a7d3a',
+  stone: '#888888',
+  brick: '#b75555',
+  dirt: '#8b5a2b',
+  water: '#3366dd'
+};
 
 interface HexGridProps {
   radius?: number;
   gridRadius?: number;
   height?: number;
-  textureUrl?: string;
+  textureMap?: Partial<Record<TileType, string>>;
 }
 
 interface HexTileProps {
   position: Vec3;
   radius: number;
   height: number;
-  textureUrl?: string;
+  type: TileType;
+  textureMap?: Partial<Record<TileType, string>>;
 }
 
-const HexTile: React.FC<HexTileProps> = ({ position, radius, height, textureUrl }) => {
-  const texture = textureUrl ? useLoader(TextureLoader, textureUrl) : undefined;
+const HexTile: React.FC<HexTileProps> = ({ position, radius, height, type, textureMap }) => {
+  const texturePath = textureMap?.[type];
+  const texture = texturePath ? useLoader(TextureLoader, texturePath) : undefined;
 
   // CylinderGeometry groups: 0 - side, 1 - top, 2 - bottom
   const materials = useMemo(() => {
     const side = { color: '#333333' } as const;
-    const top = texture ? { map: texture } : { color: '#666666' };
+    const top = texture ? { map: texture } : { color: TILE_COLORS[type] };
     const mat = [side, top, top];
     return mat;
-  }, [texture]);
+  }, [texture, type]);
 
   return (
     <mesh position={position} rotation={[0, 0, 0]}>
@@ -35,20 +48,23 @@ const HexTile: React.FC<HexTileProps> = ({ position, radius, height, textureUrl 
       {materials.map((props, idx) => (
         <meshStandardMaterial key={idx} attach={`material-${idx}`} {...props} />
       ))}
+      <Edges scale={1.02} color="#000" />
     </mesh>
   );
 };
 
-const HexGrid: React.FC<HexGridProps> = ({ radius = 1, gridRadius = 2, height = 0.2, textureUrl }) => {
-  const tiles: Vec3[] = useMemo(() => {
-    const arr: Vec3[] = [];
+const HexGrid: React.FC<HexGridProps> = ({ radius = 1, gridRadius = 2, height = 0.2, textureMap }) => {
+  const types: TileType[] = Object.keys(TILE_COLORS) as TileType[];
+  const tiles = useMemo(() => {
+    const arr: { pos: Vec3; type: TileType }[] = [];
     for (let q = -gridRadius; q <= gridRadius; q++) {
       const r1 = Math.max(-gridRadius, -q - gridRadius);
       const r2 = Math.min(gridRadius, -q + gridRadius);
       for (let r = r1; r <= r2; r++) {
         const x = radius * Math.sqrt(3) * (q + r / 2);
         const z = radius * 1.5 * r;
-        arr.push([x, 0, z]);
+        const type = types[Math.floor(Math.random() * types.length)];
+        arr.push({ pos: [x, 0, z], type });
       }
     }
     return arr;
@@ -56,8 +72,8 @@ const HexGrid: React.FC<HexGridProps> = ({ radius = 1, gridRadius = 2, height = 
 
   return (
     <group>
-      {tiles.map((pos, idx) => (
-        <HexTile key={idx} position={pos} radius={radius} height={height} textureUrl={textureUrl} />
+      {tiles.map(({ pos, type }, idx) => (
+        <HexTile key={idx} position={pos} radius={radius} height={height} type={type} textureMap={textureMap} />
       ))}
     </group>
   );

--- a/src/components/battle/index.ts
+++ b/src/components/battle/index.ts
@@ -6,3 +6,4 @@ export { default as BattleLog } from './BattleLog';
 export { default as PlayerHand } from './PlayerHand';
 export { default as WizardStats } from './WizardStats';
 export { default as HexGrid } from './HexGrid';
+export { TILE_COLORS } from './HexGrid';


### PR DESCRIPTION
## Summary
- merge branch for hex grid features
- import hex grid utilities into battle scene
- allow hex grid tile textures via `textureMap`
- export `TILE_COLORS` for reuse

## Testing
- `npm test` *(fails: saveModule tests)*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68438c7f34d883338087bd6ee7fc183f