### PR TITLE
Fix HexGrid runtime error

### DIFF
--- a/src/components/battle/HexGrid.tsx
+++ b/src/components/battle/HexGrid.tsx
@@ -1,7 +1,5 @@
 import React, { useMemo, useEffect, useState } from 'react';
 import { TextureLoader, Texture } from 'three';
-import { useLoader } from '@react-three/fiber';
- main
 import { Edges } from '@react-three/drei';
 
 type Vec3 = [number, number, number];
@@ -63,7 +61,6 @@ const useOptionalTexture = (url?: string) => {
 const HexTile: React.FC<HexTileProps> = ({ position, radius, height, type, textureMap }) => {
   const texturePath = textureMap?.[type];
   const texture = useOptionalTexture(texturePath);
- main
 
   // CylinderGeometry groups: 0 - side, 1 - top, 2 - bottom
   const materials = useMemo(() => {

--- a/src/lib/game-state/__tests__/saveModule.test.ts
+++ b/src/lib/game-state/__tests__/saveModule.test.ts
@@ -12,10 +12,8 @@ class MemoryStorage implements Storage {
   private store: Record<string, string> = {};
   length = 0;
   clear() {
- codex/add-save-slot-isolation-tests
     this.store = {};
     this.length = 0;
- main
   }
   getItem(key: string) {
     return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null;


### PR DESCRIPTION
## Summary
- remove stray tokens in `HexGrid.tsx`
- clean up stray debug lines in `saveModule.test.ts`

## Testing
- `npm test` *(fails: fetch ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6843a16f19888333b4c5b4cf49130fe2