### PR TITLE
Snap wizards to hex grid

### DIFF
--- a/docs/technical_documentation.md
+++ b/docs/technical_documentation.md
@@ -358,6 +358,18 @@ The battle system provides an immersive 3D experience using Three.js via React T
 - **AXIOM 45**: Use consistent color themes and visual language across all spell effects.
 - **AXIOM 46**: Design visual effects to communicate gameplay information (damage type, effect strength).
 
+## Hex Grid System
+
+The battle arena uses a hexagonal grid as the basis for future tactical movement mechanics. The grid is generated in `HexGrid.tsx` and all entity positions are aligned to hex centers using utilities from `src/lib/utils/hexUtils.ts`.
+
+### Key Points
+1. Hex tiles use axial coordinates `(q, r)` with pointy-top orientation.
+2. `axialToWorld()` converts a tile coordinate to a Three.js world position.
+3. `snapToHexCenter()` snaps any world position to the nearest hex center for consistent placement.
+4. Player and enemy wizards start at `(-2, 0)` and `(2, 0)` respectively, leaving three empty tiles between them.
+
+This grid forms the foundation for a tactical movement system planned for future updates. All movement and range calculations will operate on these axial coordinates.
+
 ## Equipment System
 
 The equipment system allows players to customize their wizard with:

--- a/src/components/battle/BattleScene.tsx
+++ b/src/components/battle/BattleScene.tsx
@@ -6,6 +6,7 @@ import { Environment, Stars, Text, OrbitControls } from '@react-three/drei';
 import SpellEffect3D from './effects/SpellEffect3D';
 import WizardModel from './WizardModel';
 import HexGrid, { TILE_COLORS } from './HexGrid';
+import { axialToWorld } from '@/lib/utils/hexUtils';
 import { Spell, ActiveEffect } from '../../lib/types/spell-types';
 import { CombatState, CombatLogEntry, CombatWizard } from '../../lib/types/combat-types';
 
@@ -213,16 +214,16 @@ const BattleSceneContent: React.FC<BattleSceneProps> = (props) => {
       </group>
       
       {/* Player wizard */}
-      <WizardModel 
-        position={[-2.5, 0, 0]} 
+      <WizardModel
+        position={axialToWorld({ q: -2, r: 0 })}
         color={theme.colors.primary.main}
         health={playerHealth / playerMaxHealth}
         isActive={combatState ? (combatState.isPlayerTurn && combatState.status === 'active') : true}
       />
       
       {/* Enemy wizard */}
-      <WizardModel 
-        position={[2.5, 0, 0]} 
+      <WizardModel
+        position={axialToWorld({ q: 2, r: 0 })}
         color={theme.colors.secondary.main}
         isEnemy={true}
         health={enemyHealth / enemyMaxHealth}

--- a/src/lib/utils/__tests__/hexUtils.test.ts
+++ b/src/lib/utils/__tests__/hexUtils.test.ts
@@ -1,0 +1,19 @@
+import { axialToWorld, worldToAxial, snapToHexCenter } from '../hexUtils';
+
+test('axialToWorld converts axial coords to world space', () => {
+  const pos = axialToWorld({ q: 1, r: -1 });
+  expect(pos[0]).toBeCloseTo(Math.sqrt(3) / 2);
+  expect(pos[2]).toBeCloseTo(-1.5);
+});
+
+test('worldToAxial converts world space to axial coords', () => {
+  const coord = worldToAxial([Math.sqrt(3) / 2, 0, -1.5]);
+  expect(coord.q).toBeCloseTo(1);
+  expect(coord.r).toBeCloseTo(-1);
+});
+
+test('snapToHexCenter snaps to nearest tile center', () => {
+  const snapped = snapToHexCenter([0.9, 0, 0.2]);
+  expect(snapped[0]).toBeCloseTo(Math.sqrt(3));
+  expect(snapped[2]).toBeCloseTo(0);
+});

--- a/src/lib/utils/hexUtils.ts
+++ b/src/lib/utils/hexUtils.ts
@@ -1,0 +1,63 @@
+export interface AxialCoord {
+  q: number;
+  r: number;
+}
+
+/**
+ * Convert axial hex coordinates to world space 3D coordinates.
+ * @param coord - axial coordinates {q, r}
+ * @param radius - hex tile radius
+ */
+export function axialToWorld(coord: AxialCoord, radius = 1): [number, number, number] {
+  const x = radius * Math.sqrt(3) * (coord.q + coord.r / 2);
+  const z = radius * 1.5 * coord.r;
+  return [x, 0, z];
+}
+
+/**
+ * Convert world space coordinates to axial hex coordinates.
+ * @param position - [x, y, z] world coords
+ * @param radius - hex tile radius
+ */
+export function worldToAxial(position: [number, number, number], radius = 1): AxialCoord {
+  const [x, , z] = position;
+  const q = (Math.sqrt(3)/3 * x - 1/3 * z) / radius;
+  const r = (2/3 * z) / radius;
+  return { q, r };
+}
+
+/**
+ * Round fractional axial coordinates to the nearest hex tile.
+ */
+export function roundAxial(q: number, r: number): AxialCoord {
+  let x = q;
+  let y = r;
+  let z = -x - y;
+
+  let rx = Math.round(x);
+  let ry = Math.round(y);
+  let rz = Math.round(z);
+
+  const xDiff = Math.abs(rx - x);
+  const yDiff = Math.abs(ry - y);
+  const zDiff = Math.abs(rz - z);
+
+  if (xDiff > yDiff && xDiff > zDiff) {
+    rx = -ry - rz;
+  } else if (yDiff > zDiff) {
+    ry = -rx - rz;
+  } else {
+    rz = -rx - ry;
+  }
+
+  return { q: rx, r: ry };
+}
+
+/**
+ * Snap a world space position to the center of the nearest hex tile.
+ */
+export function snapToHexCenter(position: [number, number, number], radius = 1): [number, number, number] {
+  const axial = worldToAxial(position, radius);
+  const rounded = roundAxial(axial.q, axial.r);
+  return axialToWorld(rounded, radius);
+}


### PR DESCRIPTION
## Summary
- add hex grid utilities for axial coordinate math
- position wizards with axial coordinates so they stand on tile centers
- document the hex grid movement system in technical docs
- test axial/hex conversion helpers

## Testing
- `npx jest src/lib/utils/__tests__/hexUtils.test.ts --silent`
- `npm test --silent` *(fails: saveModule.test.ts cannot connect to localhost)*
- `npm run lint` *(fails: many lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6843adef4c008333a16b694d62466999