### PR TITLE
Add enemy model mapping

### DIFF
--- a/src/components/battle/BattleScene.tsx
+++ b/src/components/battle/BattleScene.tsx
@@ -229,6 +229,7 @@ const BattleSceneContent: React.FC<BattleSceneProps> = (props) => {
         health={enemyHealth / enemyMaxHealth}
         isActive={combatState ? (!combatState.isPlayerTurn && combatState.status === 'active') : false}
         enemyVariant={Math.round(Math.random()) as 0 | 1}
+        modelPath={combatState?.enemyWizard.wizard.modelPath}
       />
       
       {/* Render active spell effects - adjusted for tighter view */}

--- a/src/components/battle/BattleView.tsx
+++ b/src/components/battle/BattleView.tsx
@@ -173,6 +173,7 @@ const BattleView: React.FC<BattleViewProps> = ({ onReturnToWizardStudy }) => {
     const rawEnemy = generateEnemy(playerWizard.level, difficulty);
     const enemyWizard = {
       ...rawEnemy,
+      modelPath: rawEnemy.modelPath,
       experience: 0,
       experienceToNextLevel: 100,
       manaRegen: 1,

--- a/src/components/battle/WizardModel.tsx
+++ b/src/components/battle/WizardModel.tsx
@@ -2,7 +2,7 @@
 
 import React, { useRef, useState, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { Text, useGLTF } from '@react-three/drei';
+import { Text, useGLTF, useFBX } from '@react-three/drei';
 import { Mesh, Vector3 } from 'three';
 
 interface WizardModelProps {
@@ -12,6 +12,7 @@ interface WizardModelProps {
   isActive?: boolean;
   isEnemy?: boolean;
   enemyVariant?: 0 | 1; // 0: original, 1: alternate
+  modelPath?: string;
 }
 
 const PLAYER_WIZARD_GLB_PATH = '/assets/player-wizard-01.glb';
@@ -215,7 +216,8 @@ const WizardModel: React.FC<WizardModelProps> = ({
   health,
   isActive = false,
   isEnemy = false,
-  enemyVariant = 0
+  enemyVariant = 0,
+  modelPath
 }) => {
   // Player: use GLB model
   if (!isEnemy) {
@@ -268,7 +270,51 @@ const WizardModel: React.FC<WizardModelProps> = ({
       </group>
     );
   }
-  // Enemy: use primitive model, select variant
+  // Enemy: use custom model if provided, otherwise primitive model
+  if (modelPath) {
+    // Load FBX model
+    const { scene } = useFBX(modelPath);
+    const getHealthColor = () => {
+      if (health > 0.6) return '#44ff44';
+      if (health > 0.3) return '#ffff00';
+      return '#ff4444';
+    };
+    return (
+      <group position={position}>
+        <primitive
+          object={scene}
+          scale={[0.02, 0.02, 0.02]}
+          rotation={[0, Math.PI, 0]}
+        />
+        <group position={[0, 2, 0]}>
+          <mesh position={[0, 0, 0]}>
+            <boxGeometry args={[1.2, 0.15, 0.05]} />
+            <meshStandardMaterial color="#222222" roughness={0.5} />
+          </mesh>
+          <mesh position={[0, 0, 0.03]} scale={[health, 1, 1]}>
+            <boxGeometry args={[1.2, 0.15, 0.05]} />
+            <meshStandardMaterial
+              color={getHealthColor()}
+              emissive={getHealthColor()}
+              emissiveIntensity={0.5}
+              roughness={0.3}
+            />
+          </mesh>
+          <Text
+            position={[0, 0, 0.1]}
+            fontSize={0.1}
+            color="#ffffff"
+            anchorX="center"
+            anchorY="middle"
+            outlineWidth={0.01}
+            outlineColor="#000000"
+          >
+            {Math.floor(health * 100)}%
+          </Text>
+        </group>
+      </group>
+    );
+  }
   return (
     <PrimitiveWizardModel
       position={position}

--- a/src/lib/features/procedural/enemyArchetypes.ts
+++ b/src/lib/features/procedural/enemyArchetypes.ts
@@ -14,6 +14,8 @@ export interface EnemyArchetype {
     manaMultiplier: number;
     manaRegenMultiplier: number;
   };
+  /** Optional path to a 3D model for this archetype */
+  modelPath?: string;
   getSpecialSpell: (level: number) => Spell;
   getThematicSpells: (level: number) => Spell[];
 }
@@ -33,6 +35,7 @@ export const enemyArchetypes: Record<string, EnemyArchetype> = {
       manaMultiplier: 1.3,
       manaRegenMultiplier: 1.1
     },
+    modelPath: '/assets/Skull.fbx',
     getSpecialSpell: (level: number): Spell => ({
       id: `spell_summon_undead_${Date.now()}`,
       name: 'Summon Undead Minion',
@@ -126,6 +129,7 @@ export const enemyArchetypes: Record<string, EnemyArchetype> = {
       manaMultiplier: 1.5,
       manaRegenMultiplier: 1.3
     },
+    modelPath: '/assets/Wizzir.fbx',
     getSpecialSpell: (level: number): Spell => ({
       id: `spell_time_rewind_${Date.now()}`,
       name: 'Time Rewind',
@@ -209,6 +213,7 @@ export const enemyArchetypes: Record<string, EnemyArchetype> = {
       manaMultiplier: 0.8,
       manaRegenMultiplier: 1.0
     },
+    modelPath: '/assets/Bloody.fbx',
     getSpecialSpell: (level: number): Spell => ({
       id: `spell_weapon_enhancement_${Date.now()}`,
       name: 'Weapon Enhancement',
@@ -298,6 +303,7 @@ export const enemyArchetypes: Record<string, EnemyArchetype> = {
       manaMultiplier: 1.2,
       manaRegenMultiplier: 1.1
     },
+    modelPath: '/assets/David.fbx',
     getSpecialSpell: (level: number): Spell => ({
       id: `spell_mirror_image_${Date.now()}`,
       name: 'Mirror Image',
@@ -380,6 +386,7 @@ export const enemyArchetypes: Record<string, EnemyArchetype> = {
       manaMultiplier: 1.1,
       manaRegenMultiplier: 1.2
     },
+    modelPath: '/assets/Pipe.fbx',
     getSpecialSpell: (level: number): Spell => ({
       id: `spell_potion_throw_${Date.now()}`,
       name: 'Potion Throw',

--- a/src/lib/features/procedural/enemyGenerator.ts
+++ b/src/lib/features/procedural/enemyGenerator.ts
@@ -135,6 +135,7 @@ function generateEnemyWizard(playerLevel: number, difficulty: 'easy' | 'normal' 
     weakness: archetype.weakness || undefined,
     resistance: archetype.resistance || undefined,
     imagePath: `/images/enemies/${archetype.id}.jpg`,
+    modelPath: archetype.modelPath,
     equipment,
     archetype: archetypeKey // Always set to the key for robust UI mapping
   };
@@ -266,6 +267,7 @@ function generateMagicalCreature(playerLevel: number, difficulty: 'easy' | 'norm
     weakness: creature.weaknesses[Math.floor(Math.random() * creature.weaknesses.length)],
     resistance: creature.resistances[Math.floor(Math.random() * creature.resistances.length)],
     imagePath: `/images/creatures/${creature.type}.jpg`,
+    modelPath: creature.modelPath,
     archetype: creature.type
   };
 }

--- a/src/lib/features/procedural/magicalCreatures.ts
+++ b/src/lib/features/procedural/magicalCreatures.ts
@@ -3,6 +3,8 @@ import { Spell, ElementType, SpellType } from '../../types';
 export interface MagicalCreature {
   name: string;
   type: 'dragon' | 'horror' | 'guardian' | 'elemental' | 'leviathan';
+  /** Optional path to a 3D model for this creature */
+  modelPath?: string;
   description: string;
   baseStats: {
     health: number;
@@ -40,6 +42,7 @@ export const magicalCreatures: Record<string, MagicalCreature> = {
   ancientDragon: {
     name: 'Ancient Dragon',
     type: 'dragon',
+    modelPath: '/assets/PyreSorcerer.fbx',
     description: 'A massive dragon that has lived for centuries, wielding the power of fire and commanding the skies.',
     baseStats: {
       health: 150,
@@ -119,6 +122,7 @@ export const magicalCreatures: Record<string, MagicalCreature> = {
   eldritchHorror: {
     name: 'Eldritch Horror',
     type: 'horror',
+    modelPath: '/assets/HorrorNurse.fbx',
     description: 'An incomprehensible being from beyond the void, warping reality with its mere presence.',
     baseStats: {
       health: 140,
@@ -198,6 +202,7 @@ export const magicalCreatures: Record<string, MagicalCreature> = {
   natureGuardian: {
     name: 'Nature Guardian',
     type: 'guardian',
+    modelPath: '/assets/Witch.fbx',
     description: 'A massive being of living wood and stone, protecting the natural world with its immense power.',
     baseStats: {
       health: 170,
@@ -276,6 +281,7 @@ export const magicalCreatures: Record<string, MagicalCreature> = {
   stormElemental: {
     name: 'Storm Elemental',
     type: 'elemental',
+    modelPath: '/assets/Scarecrow.fbx',
     description: 'A being of pure lightning and wind, moving with incredible speed and striking with thunderous force.',
     baseStats: {
       health: 130,
@@ -354,6 +360,7 @@ export const magicalCreatures: Record<string, MagicalCreature> = {
   abyssalLeviathan: {
     name: 'Abyssal Leviathan',
     type: 'leviathan',
+    modelPath: '/assets/Devil.fbx',
     description: 'A massive creature from the depths of the ocean, wielding the power of water and darkness.',
     baseStats: {
       health: 160,

--- a/src/lib/types/enemy-types.ts
+++ b/src/lib/types/enemy-types.ts
@@ -30,6 +30,8 @@ export interface Enemy {
   weakness?: ElementType;
   resistance?: ElementType;
   imagePath?: string;
+  /** Optional path to a 3D model for this enemy */
+  modelPath?: string;
   equipment?: Record<string, Equipment | undefined>;
   archetype?: string;
 }

--- a/src/lib/types/wizard-types.ts
+++ b/src/lib/types/wizard-types.ts
@@ -11,6 +11,8 @@ export interface Wizard {
   id: string;
   name: string;
   level: number;
+  /** Optional path to a 3D model for rendering this wizard */
+  modelPath?: string;
   experience: number;
   experienceToNextLevel: number;
   /** @deprecated Use totalMaxHealth instead. */


### PR DESCRIPTION
## Summary
- support `modelPath` for wizards and enemies
- map FBX models for some archetypes and magical creatures
- load FBX models in `WizardModel`

## Testing
- `npm test` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6843b7ae14748333ab4ce4153d49e087