### PR TITLE
Fix enemy models not loading

### DIFF
--- a/src/components/battle/BattleArena.tsx
+++ b/src/components/battle/BattleArena.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import styles from './BattleArena.module.css';
 import BattleScene from './BattleScene';
+import { CombatState } from '@/lib/types';
 import WizardStats from './WizardStats';
 import BattleLog from './BattleLog';
 import { Spell, ActiveEffect } from '../../lib/types/spell-types';
@@ -43,6 +44,7 @@ interface BattleArenaProps {
   playerName?: string;
   playerLevel?: number;
   enemyLevel?: number;
+  combatState?: CombatState;
 }
 
 const BattleArena: React.FC<BattleArenaProps> = ({
@@ -76,7 +78,8 @@ const BattleArena: React.FC<BattleArenaProps> = ({
   enemyName,
   playerName,
   playerLevel,
-  enemyLevel
+  enemyLevel,
+  combatState
 }) => {
   // Track if we're on a mobile device
   const [isMobile, setIsMobile] = useState(false);
@@ -152,6 +155,8 @@ const BattleArena: React.FC<BattleArenaProps> = ({
               enemyMaxHealth={enemyMaxHealth}
               animating={animating}
               currentPhase={currentPhase}
+              combatState={combatState}
+              log={battleLog}
             />
           </div>
 
@@ -309,6 +314,8 @@ const BattleArena: React.FC<BattleArenaProps> = ({
               enemyMaxHealth={enemyMaxHealth}
               animating={animating}
               currentPhase={currentPhase}
+              combatState={combatState}
+              log={battleLog}
             />
           </div>
 

--- a/src/components/battle/BattleView.tsx
+++ b/src/components/battle/BattleView.tsx
@@ -1394,6 +1394,7 @@ const BattleView: React.FC<BattleViewProps> = ({ onReturnToWizardStudy }) => {
             playerName={playerDisplayName}
             playerLevel={playerLevel}
             enemyLevel={enemyLevel}
+            combatState={combatState}
           />
 
           {/* Phase Tracker is now only in BattleArena component */}


### PR DESCRIPTION
## Summary
- pass combat state through BattleView -> BattleArena -> BattleScene
- ensure BattleScene receives combatState and log props

## Testing
- `npm test` *(fails: TypeError: fetch failed)*
- `npm run lint` *(fails with numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843beb2e4288333981e9b3c1285b736