### PR TITLE
Switch enemy models to VRM

### DIFF
--- a/src/components/battle/WizardModel.tsx
+++ b/src/components/battle/WizardModel.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import React, { useRef, useState, useEffect } from 'react';
-import { useFrame } from '@react-three/fiber';
+import { useFrame, useLoader } from '@react-three/fiber';
 import { Text, useGLTF, useFBX } from '@react-three/drei';
+import { VRMLoader } from 'three-stdlib';
 import { Mesh, Vector3 } from 'three';
 import * as THREE from 'three';
 
@@ -260,7 +261,12 @@ const WizardModel: React.FC<WizardModelProps> = ({
   let scene: any = null;
   if (isValidModelPath) {
     try {
-      scene = useFBX(modelPath!);
+      if (modelPath!.toLowerCase().endsWith('.vrm')) {
+        const gltf = useLoader(VRMLoader, modelPath!);
+        scene = gltf.scene;
+      } else {
+        scene = useFBX(modelPath!);
+      }
       // Traverse and fix materials if needed
       scene.traverse((child: any) => {
         if (child.isMesh) {

--- a/src/lib/features/procedural/enemyArchetypes.ts
+++ b/src/lib/features/procedural/enemyArchetypes.ts
@@ -35,7 +35,7 @@ export const enemyArchetypes: Record<string, EnemyArchetype> = {
       manaMultiplier: 1.3,
       manaRegenMultiplier: 1.1
     },
-    modelPath: '/assets/Skull.fbx',
+    modelPath: '/assets/Skull.vrm',
     getSpecialSpell: (level: number): Spell => ({
       id: `spell_summon_undead_${Date.now()}`,
       name: 'Summon Undead Minion',
@@ -129,7 +129,7 @@ export const enemyArchetypes: Record<string, EnemyArchetype> = {
       manaMultiplier: 1.5,
       manaRegenMultiplier: 1.3
     },
-    modelPath: '/assets/Wizzir.fbx',
+    modelPath: '/assets/Wizzir.vrm',
     getSpecialSpell: (level: number): Spell => ({
       id: `spell_time_rewind_${Date.now()}`,
       name: 'Time Rewind',
@@ -213,7 +213,7 @@ export const enemyArchetypes: Record<string, EnemyArchetype> = {
       manaMultiplier: 0.8,
       manaRegenMultiplier: 1.0
     },
-    modelPath: '/assets/Bloody.fbx',
+    modelPath: '/assets/Bloody.vrm',
     getSpecialSpell: (level: number): Spell => ({
       id: `spell_weapon_enhancement_${Date.now()}`,
       name: 'Weapon Enhancement',
@@ -303,7 +303,7 @@ export const enemyArchetypes: Record<string, EnemyArchetype> = {
       manaMultiplier: 1.2,
       manaRegenMultiplier: 1.1
     },
-    modelPath: '/assets/David.fbx',
+    modelPath: '/assets/David.vrm',
     getSpecialSpell: (level: number): Spell => ({
       id: `spell_mirror_image_${Date.now()}`,
       name: 'Mirror Image',
@@ -386,7 +386,7 @@ export const enemyArchetypes: Record<string, EnemyArchetype> = {
       manaMultiplier: 1.1,
       manaRegenMultiplier: 1.2
     },
-    modelPath: '/assets/Pipe.fbx',
+    modelPath: '/assets/Pipe.vrm',
     getSpecialSpell: (level: number): Spell => ({
       id: `spell_potion_throw_${Date.now()}`,
       name: 'Potion Throw',

--- a/src/lib/features/procedural/magicalCreatures.ts
+++ b/src/lib/features/procedural/magicalCreatures.ts
@@ -42,7 +42,7 @@ export const magicalCreatures: Record<string, MagicalCreature> = {
   ancientDragon: {
     name: 'Ancient Dragon',
     type: 'dragon',
-    modelPath: '/assets/PyreSorcerer.fbx',
+    modelPath: '/assets/PyreSorcerer.vrm',
     description: 'A massive dragon that has lived for centuries, wielding the power of fire and commanding the skies.',
     baseStats: {
       health: 150,
@@ -122,7 +122,7 @@ export const magicalCreatures: Record<string, MagicalCreature> = {
   eldritchHorror: {
     name: 'Eldritch Horror',
     type: 'horror',
-    modelPath: '/assets/HorrorNurse.fbx',
+    modelPath: '/assets/HorrorNurse.vrm',
     description: 'An incomprehensible being from beyond the void, warping reality with its mere presence.',
     baseStats: {
       health: 140,
@@ -202,7 +202,7 @@ export const magicalCreatures: Record<string, MagicalCreature> = {
   natureGuardian: {
     name: 'Nature Guardian',
     type: 'guardian',
-    modelPath: '/assets/Witch.fbx',
+    modelPath: '/assets/Witch.vrm',
     description: 'A massive being of living wood and stone, protecting the natural world with its immense power.',
     baseStats: {
       health: 170,
@@ -281,7 +281,7 @@ export const magicalCreatures: Record<string, MagicalCreature> = {
   stormElemental: {
     name: 'Storm Elemental',
     type: 'elemental',
-    modelPath: '/assets/Scarecrow.fbx',
+    modelPath: '/assets/Scarecrow.vrm',
     description: 'A being of pure lightning and wind, moving with incredible speed and striking with thunderous force.',
     baseStats: {
       health: 130,
@@ -360,7 +360,7 @@ export const magicalCreatures: Record<string, MagicalCreature> = {
   abyssalLeviathan: {
     name: 'Abyssal Leviathan',
     type: 'leviathan',
-    modelPath: '/assets/Devil.fbx',
+    modelPath: '/assets/Devil.vrm',
     description: 'A massive creature from the depths of the ocean, wielding the power of water and darkness.',
     baseStats: {
       health: 160,


### PR DESCRIPTION
## Summary
- swap FBX paths with VRM versions for magical creatures and enemy archetypes
- load VRM files in `WizardModel` using `VRMLoader`

## Testing
- `npm test` *(fails: connect ECONNREFUSED)*
- `npm run lint` *(fails: numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843dfacd9888333ac3b4b3d566a650a