### PR TITLE
Fix item type mapping in market

### DIFF
--- a/src/components/market/MarketUI.tsx
+++ b/src/components/market/MarketUI.tsx
@@ -772,7 +772,14 @@ export const MarketUI: React.FC<{ onClose: (attackInfo?: any) => void }> = ({ on
 
               <div className={itemGridStyles.itemGrid}>
                 {getDisplayItems().map((item: MarketItemType<any>, index: number) => {
-                  let itemType = selectedTab === 'spellScrolls' ? 'scroll' : selectedTab;
+                  let itemType =
+                    selectedTab === 'spellScrolls'
+                      ? 'scroll'
+                      : selectedTab === 'potions'
+                      ? 'potion'
+                      : selectedTab === 'ingredients'
+                      ? 'ingredient'
+                      : selectedTab;
                   return (
                     <MarketItemCard
                       key={index}


### PR DESCRIPTION
## Summary
- fix MarketUI plural/singular tab mapping for items

## Testing
- `npm test` *(fails: Test Suites: 1 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6845b9df17d08333aabdc2e15e17cb57