### PR TITLE
Add minion types and battlefield positions

### DIFF
--- a/src/lib/combat/spellExecutor.ts
+++ b/src/lib/combat/spellExecutor.ts
@@ -455,16 +455,21 @@ export function applySpellEffect(
 
     case 'summon': {
       const owner = isPlayerCaster ? 'player' : 'enemy';
-      const minion = {
+      const minion: Minion = {
         id: `minion-${Date.now()}-${Math.random().toString(36).slice(2)}`,
         name: effect.minionName || 'Minion',
         owner,
+        ownerId: isPlayerCaster
+          ? newState.playerWizard.wizard.id
+          : newState.enemyWizard.wizard.id,
         modelPath: effect.modelPath,
-        health: effect.health || 10,
-        maxHealth: effect.health || 10,
         position: { q: 0, r: 0 } as import('../utils/hexUtils').AxialCoord,
+        stats: {
+          health: effect.health || 10,
+          maxHealth: effect.health || 10,
+        },
         remainingDuration: effect.duration || 1,
-      } as Minion;
+      };
 
       const casterPos = newState[caster].position || { q: owner === 'player' ? -2 : 2, r: 0 };
       const occupied = [
@@ -553,7 +558,9 @@ function processMinionActions(state: CombatState, isPlayerCaster: boolean): Comb
     });
     minion.remainingDuration -= 1;
   }
-  const filtered = list.filter(m => m.remainingDuration > 0 && m.health > 0);
+  const filtered = list.filter(
+    m => m.remainingDuration > 0 && m.stats.health > 0
+  );
   if (isPlayerCaster) {
     newState.playerMinions = filtered;
   } else {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,6 +8,7 @@ export * from './types/spell-types';
 export * from './types/equipment-types';
 export * from './types/wizard-types';
 export * from './types/enemy-types';
+export * from './types/minion-types';
 export * from './types/combat-types';
 export * from './types/game-types';
 export * from './types/market-types';

--- a/src/lib/types/combat-types.ts
+++ b/src/lib/types/combat-types.ts
@@ -5,6 +5,7 @@ import { ElementType } from './element-types';
 import { Spell, ActiveEffect } from './spell-types';
 import { Wizard } from './wizard-types';
 import { AxialCoord } from '../utils/hexUtils';
+import { Minion } from './minion-types';
 
 /**
  * Combat state
@@ -88,21 +89,9 @@ export interface CombatWizard {
   equippedPotions: import('./equipment-types').Potion[];
   equippedSpellScrolls: import('./equipment-types').Equipment[];
   /** Position on the battlefield */
-  position?: AxialCoord;
-  /** Minions belonging to this wizard (legacy field, prefer playerMinions/enemyMinions) */
-  minions?: Minion[];
-}
-
-/** A summoned minion on the battlefield */
-export interface Minion {
-  id: string;
-  name: string;
-  owner: 'player' | 'enemy';
-  modelPath?: string;
-  health: number;
-  maxHealth: number;
   position: AxialCoord;
-  remainingDuration: number;
+  /** Minions controlled directly by this wizard */
+  minions: Minion[];
 }
 
 /**

--- a/src/lib/types/minion-types.ts
+++ b/src/lib/types/minion-types.ts
@@ -1,0 +1,27 @@
+// src/lib/types/minion-types.ts
+// Types for summoned minions on the battlefield
+
+import { AxialCoord } from '../utils/hexUtils';
+
+/** Basic stats for a minion */
+export interface MinionStats {
+  health: number;
+  maxHealth: number;
+  attack?: number;
+  defense?: number;
+}
+
+/** A summoned minion on the battlefield */
+export interface Minion {
+  id: string;
+  name: string;
+  /** Wizard ID that controls this minion */
+  ownerId: string;
+  /** 'player' if controlled by the player, otherwise 'enemy' */
+  owner: 'player' | 'enemy';
+  modelPath?: string;
+  position: AxialCoord;
+  stats: MinionStats;
+  remainingDuration: number;
+  isFlying?: boolean;
+}

--- a/src/lib/utils/__tests__/movementManager.test.ts
+++ b/src/lib/utils/__tests__/movementManager.test.ts
@@ -37,6 +37,8 @@ test('occupancy map detects occupied tiles', () => {
       position: { q: 1, r: 0 },
       minions: []
     },
+    playerMinions: [],
+    enemyMinions: [],
     turn: 1,
     round: 1,
     isPlayerTurn: true,


### PR DESCRIPTION
## Summary
- define `Minion` and `MinionStats` in a new `minion-types.ts`
- export new minion types from barrel file
- update `CombatWizard` to require `position` and `minions`
- initialise wizards with default positions
- spawn minions using new type structure
- adjust movement tests for new combat state shape

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: numerous existing type errors)*
- `npm test` *(fails: saveModule tests fail to load game data)*

------
https://chatgpt.com/codex/tasks/task_e_6845e8a963148333a8f0bbee7f9fdaec