### PR TITLE
Resolve merge conflicts from PR 27

### DIFF
--- a/public/data/spell_data.json
+++ b/public/data/spell_data.json
@@ -3094,18 +3094,19 @@
     {
       "id": "spell_mirror_image_mar51ert",
       "name": "Mirror Image",
-      "type": "buff",
+      "type": "summon",
       "element": "arcane",
       "tier": 3,
       "manaCost": 40,
       "description": "Creates illusory duplicates of yourself that confuse enemies and absorb attacks.",
       "effects": [
         {
-          "type": "statModifier",
-          "value": -40,
+          "type": "summon",
+          "value": 2,
           "duration": 3,
           "target": "self",
-          "element": "arcane"
+          "element": "arcane",
+          "modelPath": "caster"
         }
       ],
       "rarity": "uncommon",

--- a/public/data/spell_data.xml
+++ b/public/data/spell_data.xml
@@ -926,10 +926,10 @@
     </effects>
     <list>any</list>
   </spell>
-  <spell id="spell_mirror_image_mar51ert" name="Mirror Image" type="buff" element="arcane" tier="3" manaCost="40" rarity="uncommon" imagePath="/images/spells/special/mirror-image.jpg">
+  <spell id="spell_mirror_image_mar51ert" name="Mirror Image" type="summon" element="arcane" tier="3" manaCost="40" rarity="uncommon" imagePath="/images/spells/special/mirror-image.jpg">
     <description>Creates illusory duplicates of yourself that confuse enemies and absorb attacks.</description>
     <effects>
-      <effect type="statModifier" value="-40" target="self" element="arcane" duration="3"/>
+      <effect type="summon" value="2" target="self" element="arcane" duration="3" modelPath="caster"/>
     </effects>
     <list>any</list>
   </spell>

--- a/src/components/battle/BattleScene.tsx
+++ b/src/components/battle/BattleScene.tsx
@@ -50,6 +50,9 @@ const BattleSceneContent: React.FC<BattleSceneProps> = (props) => {
   const prevLogLength = useRef<number>(0);
   const [reachableTiles, setReachableTiles] = useState<AxialCoord[]>([]);
   const [selectedDest, setSelectedDest] = useState<AxialCoord | null>(null);
+
+  const playerSummons = combatState?.playerWizard.activeEffects.filter(e => e.type === 'summon') || [];
+  const enemySummons = combatState?.enemyWizard.activeEffects.filter(e => e.type === 'summon') || [];
   
   // Extract props - support both old and new formats
   const {
@@ -301,6 +304,23 @@ const BattleSceneContent: React.FC<BattleSceneProps> = (props) => {
           action={playerAnim}
         />
       </Suspense>
+
+      {playerSummons.flatMap((summon, sIdx) => {
+        const base = axialToWorld({ q: -2, r: 0 });
+        const count = summon.quantity || summon.value || 1;
+        return Array.from({ length: count }).map((_, i) => (
+          <Suspense fallback={null} key={`player-summon-${sIdx}-${i}`}> 
+            <WizardModel
+              position={[base[0] - 1 - i * 0.6, base[1], base[2]] as [number, number, number]}
+              color={theme.colors.primary.main}
+              health={1}
+              isActive={false}
+              modelPath={summon.modelPath || combatState?.playerWizard.wizard.modelPath}
+              action="idle"
+            />
+          </Suspense>
+        ));
+      })}
       
       {/* Enemy wizard */}
       <Suspense fallback={null}>
@@ -315,6 +335,25 @@ const BattleSceneContent: React.FC<BattleSceneProps> = (props) => {
           action={enemyAnim}
         />
       </Suspense>
+
+      {enemySummons.flatMap((summon, sIdx) => {
+        const base = axialToWorld({ q: 2, r: 0 });
+        const count = summon.quantity || summon.value || 1;
+        return Array.from({ length: count }).map((_, i) => (
+          <Suspense fallback={null} key={`enemy-summon-${sIdx}-${i}`}> 
+            <WizardModel
+              position={[base[0] + 1 + i * 0.6, base[1], base[2]] as [number, number, number]}
+              color={theme.colors.secondary.main}
+              health={1}
+              isEnemy
+              isActive={false}
+              modelPath={summon.modelPath || combatState?.enemyWizard.wizard.modelPath}
+              enemyVariant={Math.round(Math.random()) as 0 | 1}
+              action="idle"
+            />
+          </Suspense>
+        ));
+      })}
       
       {/* Render active spell effects - adjusted for tighter view */}
       {activeEffects.map((effect, index) => (

--- a/src/components/battle/WizardStats.tsx
+++ b/src/components/battle/WizardStats.tsx
@@ -151,6 +151,8 @@ const WizardStats: React.FC<WizardStatsProps> = ({
         return 'Stunned';
       case 'silence':
         return 'Silenced';
+      case 'summon':
+        return `Summon x${effect.quantity || effect.value}`;
       default:
         return effect.name || effect.type;
     }

--- a/src/lib/combat/effectsProcessor.ts
+++ b/src/lib/combat/effectsProcessor.ts
@@ -30,6 +30,7 @@ export function processActiveEffects(
     'silence',
     'damageReduction',
     'buff',
+    'summon',
   ]);
 
   // Process each active effect

--- a/src/lib/spells/specialSpellData.ts
+++ b/src/lib/spells/specialSpellData.ts
@@ -335,18 +335,19 @@ function createMirrorImageSpell(): SpecialSpell {
   return {
     id: 'spell_mirror_image',
     name: 'Mirror Image',
-    type: 'buff',
+    type: 'summon',
     element: 'arcane',
     tier: 3,
     manaCost: 40,
     description: 'Creates illusory duplicates of yourself that confuse enemies and absorb attacks.',
     effects: [
       {
-        type: 'statModifier',
-        value: -40, // Reduced damage from attacks
+        type: 'summon',
+        value: 2,
         duration: 3,
         target: 'self',
         element: 'arcane',
+        modelPath: 'caster'
       },
     ],
     rarity: 'uncommon',

--- a/src/lib/spells/spellData.ts
+++ b/src/lib/spells/spellData.ts
@@ -49,9 +49,7 @@ function parseXmlSpells(xmlText: string): Spell[] {
           target: e.target,
           element: e.element,
           duration: e.duration !== undefined ? parseInt(e.duration, 10) : undefined,
-          minionName: e.minionName,
           modelPath: e.modelPath,
-          health: e.health !== undefined ? parseInt(e.health, 10) : undefined,
         }));
       }
       return { id, name, type, element, tier, manaCost, description, effects, imagePath, rarity } as Spell;
@@ -77,9 +75,7 @@ function parseXmlSpells(xmlText: string): Spell[] {
         target: e.getAttribute('target') as any,
         element: e.getAttribute('element') as any,
         duration: e.hasAttribute('duration') ? parseInt(e.getAttribute('duration')!, 10) : undefined,
-        minionName: e.getAttribute('minionName') || undefined,
         modelPath: e.getAttribute('modelPath') || undefined,
-        health: e.hasAttribute('health') ? parseInt(e.getAttribute('health')!, 10) : undefined,
       }));
       return { id, name, type, element, tier, manaCost, description, effects, imagePath, rarity } as Spell;
     });

--- a/src/lib/types/spell-types.ts
+++ b/src/lib/types/spell-types.ts
@@ -36,12 +36,8 @@ export interface SpellEffect {
   target: 'self' | 'enemy';
   element: ElementType;
   duration?: number;
-  /** Optional name for a summoned minion */
-  minionName?: string;
-  /** Optional path to a 3D model for the minion */
+  /** Optional path to the model used for summoned entities */
   modelPath?: string;
-  /** Health for the summoned minion */
-  health?: number;
 }
 
 /**
@@ -50,12 +46,16 @@ export interface SpellEffect {
 export interface ActiveEffect {
   id?: string;
   name: string;
-  type: 'damage_over_time' | 'healing_over_time' | 'mana_drain' | 'mana_regen' | 'stun' | 'silence' | 'damageReduction' | 'buff';
+  type: 'damage_over_time' | 'healing_over_time' | 'mana_drain' | 'mana_regen' | 'stun' | 'silence' | 'damageReduction' | 'buff' | 'summon';
   value: number;
   duration: number; // In turns
   remainingDuration: number; // Remaining turns for the effect
   source?: 'player' | 'enemy';
   effect?: SpellEffect; // The original spell effect that created this active effect
+  /** Model path for summoned entities if applicable */
+  modelPath?: string;
+  /** Number of entities summoned */
+  quantity?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add summon state to Mirror Image spell data and parsing logic
- display summoned illusions on the battle field
- handle `summon` effects in combat
- show summon status in wizard stats
- update spell types to include summon modelPath

## Testing
- `npm test` *(fails: SaveModule tests due to network fetch failure)*

------
https://chatgpt.com/codex/tasks/task_e_6845eba49e78833395697ff2ff243d77