### PR TITLE
Rebase merge conflicts for mirror image

### DIFF
--- a/public/data/spell_data.json
+++ b/public/data/spell_data.json
@@ -3094,18 +3094,19 @@
     {
       "id": "spell_mirror_image_mar51ert",
       "name": "Mirror Image",
-      "type": "buff",
+      "type": "summon",
       "element": "arcane",
       "tier": 3,
       "manaCost": 40,
       "description": "Creates illusory duplicates of yourself that confuse enemies and absorb attacks.",
       "effects": [
         {
-          "type": "statModifier",
-          "value": -40,
+          "type": "summon",
+          "value": 2,
           "duration": 3,
           "target": "self",
-          "element": "arcane"
+          "element": "arcane",
+          "modelPath": "caster"
         }
       ],
       "rarity": "uncommon",

--- a/public/data/spell_data.xml
+++ b/public/data/spell_data.xml
@@ -926,10 +926,10 @@
     </effects>
     <list>any</list>
   </spell>
-  <spell id="spell_mirror_image_mar51ert" name="Mirror Image" type="buff" element="arcane" tier="3" manaCost="40" rarity="uncommon" imagePath="/images/spells/special/mirror-image.jpg">
+  <spell id="spell_mirror_image_mar51ert" name="Mirror Image" type="summon" element="arcane" tier="3" manaCost="40" rarity="uncommon" imagePath="/images/spells/special/mirror-image.jpg">
     <description>Creates illusory duplicates of yourself that confuse enemies and absorb attacks.</description>
     <effects>
-      <effect type="statModifier" value="-40" target="self" element="arcane" duration="3"/>
+      <effect type="summon" value="2" target="self" element="arcane" duration="3" modelPath="caster"/>
     </effects>
     <list>any</list>
   </spell>

--- a/src/lib/combat/spellExecutor.ts
+++ b/src/lib/combat/spellExecutor.ts
@@ -454,53 +454,87 @@ export function applySpellEffect(
     }
 
     case 'summon': {
-      const owner = isPlayerCaster ? 'player' : 'enemy';
-      const minion: Minion = {
-        id: `minion-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-        name: effect.minionName || 'Minion',
-        owner,
-        ownerId: isPlayerCaster
-          ? newState.playerWizard.wizard.id
-          : newState.enemyWizard.wizard.id,
-        modelPath: effect.modelPath,
-        position: { q: 0, r: 0 } as import('../utils/hexUtils').AxialCoord,
-        stats: {
-          health: effect.health || 10,
-          maxHealth: effect.health || 10,
-        },
-        remainingDuration: effect.duration || 1,
-      };
+      if (effect.modelPath === 'caster') {
+        const activeEffect: ActiveEffect = {
+          id: `summon-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+          name: 'Summon',
+          source: isPlayerCaster ? 'player' : 'enemy',
+          remainingDuration: effect.duration || 1,
+          duration: effect.duration || 1,
+          type: 'summon',
+          value: effect.value,
+          effect,
+          modelPath: newState[caster].wizard.modelPath,
+          quantity: effect.value,
+        };
 
-      const casterPos = newState[caster].position || { q: owner === 'player' ? -2 : 2, r: 0 };
-      const occupied = [
-        newState.playerWizard.position || { q: -2, r: 0 },
-        newState.enemyWizard.position || { q: 2, r: 0 },
-        ...newState.playerMinions.map(m => m.position),
-        ...newState.enemyMinions.map(m => m.position),
-      ];
-      const spawn = findUnoccupiedAdjacentHex(casterPos, occupied);
-      if (spawn) {
-        minion.position = spawn;
-        if (owner === 'player') {
-          newState.playerMinions = [...newState.playerMinions, minion];
-        } else {
-          newState.enemyMinions = [...newState.enemyMinions, minion];
-        }
-        newState.log.push(createLogEntry({
-          turn: newState.turn,
-          round: newState.round,
-          actor: owner,
-          action: 'summon',
-          details: `${owner === 'player' ? 'You' : 'Enemy'} summoned ${minion.name}!`,
-        }));
+        newState[effectTarget] = {
+          ...newState[effectTarget],
+          activeEffects: [...newState[effectTarget].activeEffects, activeEffect],
+        };
+
+        newState.log.push(
+          createLogEntry({
+            turn: newState.turn,
+            round: newState.round,
+            actor: isPlayerCaster ? 'player' : 'enemy',
+            action: 'effect_applied',
+            details: `Summoned ${effect.value} illusion(s)!`,
+          })
+        );
       } else {
-        newState.log.push(createLogEntry({
-          turn: newState.turn,
-          round: newState.round,
-          actor: owner,
-          action: 'summon_failed',
-          details: 'No space to summon a minion!',
-        }));
+        const owner = isPlayerCaster ? 'player' : 'enemy';
+        const minion: Minion = {
+          id: `minion-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+          name: effect.minionName || 'Minion',
+          owner,
+          ownerId: isPlayerCaster
+            ? newState.playerWizard.wizard.id
+            : newState.enemyWizard.wizard.id,
+          modelPath: effect.modelPath,
+          position: { q: 0, r: 0 } as import('../utils/hexUtils').AxialCoord,
+          stats: {
+            health: effect.health || 10,
+            maxHealth: effect.health || 10,
+          },
+          remainingDuration: effect.duration || 1,
+        };
+
+        const casterPos = newState[caster].position || { q: owner === 'player' ? -2 : 2, r: 0 };
+        const occupied = [
+          newState.playerWizard.position || { q: -2, r: 0 },
+          newState.enemyWizard.position || { q: 2, r: 0 },
+          ...newState.playerMinions.map(m => m.position),
+          ...newState.enemyMinions.map(m => m.position),
+        ];
+        const spawn = findUnoccupiedAdjacentHex(casterPos, occupied);
+        if (spawn) {
+          minion.position = spawn;
+          if (owner === 'player') {
+            newState.playerMinions = [...newState.playerMinions, minion];
+          } else {
+            newState.enemyMinions = [...newState.enemyMinions, minion];
+          }
+          newState.log.push(
+            createLogEntry({
+              turn: newState.turn,
+              round: newState.round,
+              actor: owner,
+              action: 'summon',
+              details: `${owner === 'player' ? 'You' : 'Enemy'} summoned ${minion.name}!`,
+            })
+          );
+        } else {
+          newState.log.push(
+            createLogEntry({
+              turn: newState.turn,
+              round: newState.round,
+              actor: owner,
+              action: 'summon_failed',
+              details: 'No space to summon a minion!',
+            })
+          );
+        }
       }
       break;
     }

--- a/src/lib/spells/specialSpellData.ts
+++ b/src/lib/spells/specialSpellData.ts
@@ -335,18 +335,19 @@ function createMirrorImageSpell(): SpecialSpell {
   return {
     id: 'spell_mirror_image',
     name: 'Mirror Image',
-    type: 'buff',
+    type: 'summon',
     element: 'arcane',
     tier: 3,
     manaCost: 40,
     description: 'Creates illusory duplicates of yourself that confuse enemies and absorb attacks.',
     effects: [
       {
-        type: 'statModifier',
-        value: -40, // Reduced damage from attacks
+        type: 'summon',
+        value: 2,
         duration: 3,
         target: 'self',
         element: 'arcane',
+        modelPath: 'caster',
       },
     ],
     rarity: 'uncommon',

--- a/src/lib/types/spell-types.ts
+++ b/src/lib/types/spell-types.ts
@@ -38,7 +38,7 @@ export interface SpellEffect {
   duration?: number;
   /** Optional name for a summoned minion */
   minionName?: string;
-  /** Optional path to a 3D model for the minion */
+  /** Optional path to a 3D model for the minion or to indicate caster model */
   modelPath?: string;
   /** Health for the summoned minion */
   health?: number;
@@ -50,12 +50,17 @@ export interface SpellEffect {
 export interface ActiveEffect {
   id?: string;
   name: string;
-  type: 'damage_over_time' | 'healing_over_time' | 'mana_drain' | 'mana_regen' | 'stun' | 'silence' | 'damageReduction' | 'buff';
+  type: 'damage_over_time' | 'healing_over_time' | 'mana_drain' | 'mana_regen' |
+    'stun' | 'silence' | 'damageReduction' | 'buff' | 'summon';
   value: number;
   duration: number; // In turns
   remainingDuration: number; // Remaining turns for the effect
   source?: 'player' | 'enemy';
   effect?: SpellEffect; // The original spell effect that created this active effect
+  /** Model path for summoned entities if applicable */
+  modelPath?: string;
+  /** Number of entities summoned */
+  quantity?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- change Mirror Image from buff to summon
- spawn illusions via a new summon active effect
- extend ActiveEffect type for summoning info

## Testing
- `npm test --silent` *(fails: TypeError: fetch failed)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845ee3d86988333bcf1b5f2c8b07784