### PR TITLE
Add potion study mechanic

### DIFF
--- a/src/components/minigames/PotionStudyMinigame.module.css
+++ b/src/components/minigames/PotionStudyMinigame.module.css
@@ -1,0 +1,59 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.window {
+  background: var(--ui-card);
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+  color: var(--ui-text);
+}
+
+.instructions {
+  margin-bottom: 15px;
+}
+
+.runes {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+
+.runeButton {
+  position: relative;
+  font-size: 32px;
+  width: 50px;
+  height: 50px;
+  border: 1px solid var(--ui-card-border);
+  background: var(--ui-card-inner);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.order {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  font-size: 12px;
+  color: var(--primary-light);
+}
+
+.cancel {
+  padding: 6px 12px;
+  background-color: var(--ui-button);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/src/components/minigames/PotionStudyMinigame.tsx
+++ b/src/components/minigames/PotionStudyMinigame.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from 'react';
+import styles from './PotionStudyMinigame.module.css';
+import { RuneGrade } from '@/lib/types/minigame-types';
+
+interface PotionStudyMinigameProps {
+  sequenceLength: number;
+  onComplete: (grade: RuneGrade) => void;
+  onCancel: () => void;
+}
+
+const runes = ['\u16A0', '\u16A2', '\u16A6', '\u16B1', '\u16D2', '\u16C1'];
+
+function shuffle<T>(array: T[]): T[] {
+  const arr = [...array];
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+const PotionStudyMinigame: React.FC<PotionStudyMinigameProps> = ({
+  sequenceLength,
+  onComplete,
+  onCancel,
+}) => {
+  const [sequence, setSequence] = useState<number[]>([]);
+  const [showSequence, setShowSequence] = useState(true);
+  const [playerInput, setPlayerInput] = useState<number[]>([]);
+  const [errors, setErrors] = useState(0);
+  const [startTime, setStartTime] = useState<number>(0);
+
+  useEffect(() => {
+    const indices = shuffle(Array.from({ length: runes.length }, (_, i) => i));
+    const seq = indices.slice(0, sequenceLength);
+    setSequence(seq);
+    setTimeout(() => {
+      setShowSequence(false);
+      setStartTime(Date.now());
+    }, 3000);
+  }, [sequenceLength]);
+
+  const handleClick = (index: number) => {
+    if (showSequence) return;
+    const next = playerInput.length;
+    if (sequence[next] !== index) setErrors((e) => e + 1);
+    const newInput = [...playerInput, index];
+    setPlayerInput(newInput);
+    if (newInput.length === sequenceLength) {
+      const duration = Date.now() - startTime;
+      let grade: RuneGrade = 'average';
+      if (errors === 0 && duration < sequenceLength * 1500) grade = 'excellent';
+      else if (errors > 1 || duration > sequenceLength * 3000) grade = 'poor';
+      onComplete(grade);
+    }
+  };
+
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.window}>
+        <p className={styles.instructions}>
+          {showSequence ? 'Memorize the order' : 'Select the runes in order'}
+        </p>
+        <div className={styles.runes}>
+          {runes.slice(0, sequenceLength).map((r, i) => (
+            <button
+              key={i}
+              className={styles.runeButton}
+              onClick={() => handleClick(i)}
+            >
+              {r}
+              {showSequence && (
+                <span className={styles.order}>{sequence.indexOf(i) + 1}</span>
+              )}
+            </button>
+          ))}
+        </div>
+        <button className={styles.cancel} onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default PotionStudyMinigame;

--- a/src/components/minigames/RuneSequenceMinigame.tsx
+++ b/src/components/minigames/RuneSequenceMinigame.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import styles from './RuneSequenceMinigame.module.css';
-
-export type RuneGrade = 'poor' | 'average' | 'excellent';
+import { RuneGrade } from '@/lib/types/minigame-types';
 
 interface RuneSequenceMinigameProps {
   sequenceLength: number;

--- a/src/components/potions/PotionCraftingScreen.module.css
+++ b/src/components/potions/PotionCraftingScreen.module.css
@@ -276,3 +276,62 @@
     grid-template-rows: 1fr 1fr;
   }
 }
+
+.potionCraftingStudyMode {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  height: 100%;
+  overflow: hidden;
+}
+
+.potionCraftingPotionsList {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 15px;
+}
+
+.potionCraftingPotion {
+  background-color: var(--ui-card-inner);
+  border: 1px solid var(--ui-card-border);
+  border-radius: 8px;
+  padding: 15px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.potionCraftingPotion:hover {
+  box-shadow: 0 0 10px rgba(var(--primary-rgb), 0.3);
+  border-color: var(--primary-dark);
+}
+
+.potionCraftingPotionSelected {
+  border: 2px solid var(--primary-main);
+  box-shadow: 0 0 10px rgba(var(--primary-rgb), 0.3);
+}
+
+.potionCraftingStudyArea {
+  background-color: var(--ui-card);
+  border-radius: 8px;
+  padding: 15px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.potionCraftingStudySlot {
+  border: 1px dashed var(--ui-card-border);
+  border-radius: 8px;
+  height: 120px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.potionCraftingTimer {
+  margin-top: 10px;
+  font-weight: bold;
+  text-align: center;
+}

--- a/src/lib/features/potions/potionCrafting.ts
+++ b/src/lib/features/potions/potionCrafting.ts
@@ -343,4 +343,64 @@ export function craftPotion(
       potion
     }
   };
-} 
+}
+
+export function studyPotion(
+  wizard: Wizard,
+  potion: Potion,
+  grade: 'poor' | 'average' | 'excellent'
+): {
+  wizard: Wizard;
+  result: { success: boolean; message: string; discoveredRecipe?: PotionRecipe };
+} {
+  const updatedWizard = { ...wizard };
+  updatedWizard.potions = (updatedWizard.potions || []).filter(p => p.id !== potion.id);
+
+  const rarityMap: Record<string, number> = {
+    common: 1,
+    uncommon: 2,
+    rare: 3,
+    epic: 4,
+    legendary: 5,
+  };
+
+  const candidate = getAllPotionRecipes().find(
+    r => r.resultType === potion.type && r.resultTier === rarityMap[potion.rarity]
+  );
+
+  if (!candidate) {
+    return {
+      wizard: updatedWizard,
+      result: {
+        success: false,
+        message: 'You could not learn anything from this potion.',
+      },
+    };
+  }
+
+  const chanceMap: Record<'poor' | 'average' | 'excellent', number> = {
+    poor: 0.25,
+    average: 0.5,
+    excellent: 0.75,
+  };
+
+  if (Math.random() < chanceMap[grade]) {
+    const wiz = discoverRecipe(updatedWizard, candidate.id) || updatedWizard;
+    return {
+      wizard: wiz,
+      result: {
+        success: true,
+        message: `You learned the recipe for ${candidate.name}!`,
+        discoveredRecipe: candidate,
+      },
+    };
+  }
+
+  return {
+    wizard: updatedWizard,
+    result: {
+      success: false,
+      message: 'The study yielded no recipe.',
+    },
+  };
+}

--- a/src/lib/game-state/__tests__/potionModule.test.ts
+++ b/src/lib/game-state/__tests__/potionModule.test.ts
@@ -4,6 +4,7 @@ import { createPotionModule, PotionActions } from "../modules/potionModule";
 import { GameState, SaveSlot } from "../../types/game-types";
 import { Wizard, Ingredient, PotionRecipe, Potion } from "../../types";
 import { getAllPotionRecipes } from "../../features/potions/potionRecipes";
+import * as potionGenerator from "../../features/procedural/potionGenerator";
 
 type TestStore = PotionActions & { gameState: GameState };
 
@@ -123,4 +124,18 @@ test("craftPotion consumes ingredients and adds potion", () => {
   const state = store.getState().gameState.player!;
   expect(state.potions.length).toBe(1);
   expect(state.ingredients?.length).toBe(0);
+});
+
+test("studyPotion learns recipe and consumes potion", () => {
+  const wizard = createTestWizard(recipe);
+  const potion = potionGenerator.generateHealthPotion(recipe.resultTier);
+  wizard.potions = [potion];
+  const store = createTestStore(wizard);
+  jest.spyOn(Math, 'random').mockReturnValue(0);
+  const result = store.getState().studyPotion(potion.id, 'excellent');
+  expect(result.success).toBe(true);
+  const state = store.getState().gameState.player!;
+  expect(state.potions.length).toBe(0);
+  expect(state.discoveredRecipes?.some((r) => r.id === recipe.id)).toBe(true);
+  (Math.random as jest.Mock).mockRestore();
 });

--- a/src/lib/types/minigame-types.ts
+++ b/src/lib/types/minigame-types.ts
@@ -1,0 +1,1 @@
+export type RuneGrade = 'poor' | 'average' | 'excellent';


### PR DESCRIPTION
## Summary
- introduce shared `RuneGrade` type for minigames
- add PotionStudyMinigame component for studying potions
- extend PotionCraftingScreen with new Study tab
- implement potion study logic and wire into game state
- cover studyPotion in unit tests

## Testing
- `npm run build` *(fails: ESLint errors)*
- `npm test` *(fails: saveModule & studyPotion tests)*

------
https://chatgpt.com/codex/tasks/task_e_6845eec8b8548333918dd42aa1f63a38