### PR TITLE
Allow choosing tile for summoning

### DIFF
--- a/src/components/battle/BattleArena.tsx
+++ b/src/components/battle/BattleArena.tsx
@@ -47,6 +47,8 @@ interface BattleArenaProps {
   enemyLevel?: number;
   combatState?: CombatState;
   onMove?: (coord: AxialCoord) => void;
+  selectingSummon?: boolean;
+  onSummonTile?: (coord: AxialCoord) => void;
 }
 
 const BattleArena: React.FC<BattleArenaProps> = ({
@@ -82,7 +84,9 @@ const BattleArena: React.FC<BattleArenaProps> = ({
   playerLevel,
   enemyLevel,
   combatState,
-  onMove
+  onMove,
+  selectingSummon,
+  onSummonTile
 }) => {
   // Track if we're on a mobile device
   const [isMobile, setIsMobile] = useState(false);
@@ -161,6 +165,8 @@ const BattleArena: React.FC<BattleArenaProps> = ({
               combatState={combatState}
               log={battleLog}
               onMove={onMove}
+              selectingSummon={selectingSummon}
+              onSummonTile={onSummonTile}
             />
           </div>
 
@@ -321,6 +327,8 @@ const BattleArena: React.FC<BattleArenaProps> = ({
               combatState={combatState}
               log={battleLog}
               onMove={onMove}
+              selectingSummon={selectingSummon}
+              onSummonTile={onSummonTile}
             />
           </div>
 

--- a/src/lib/combat/phaseManager.ts
+++ b/src/lib/combat/phaseManager.ts
@@ -420,7 +420,7 @@ function resolveQueuedEffects(state: CombatState): CombatState {
         continue; // Skip this effect, do not penalize player
       }
       newState = selectSpell(newState, effect.spell, effect.caster === 'player');
-      newState = executeSpellCast(newState, effect.caster === 'player', true);
+      newState = executeSpellCast(newState, effect.caster === 'player', true, effect.spawnCoord);
       console.log(`resolveQueuedEffects: Successfully resolved spell ${effect.spell.name} for ${caster}.`);
     } else if (effect.spellTier !== undefined) {
       // It's a mystic punch
@@ -499,6 +499,7 @@ export function queueAction(
   // Create the full effect
   const effect: QueuedEffect = {
     ...queuedEffect,
+    spawnCoord: queuedEffect.spawnCoord,
     id: `effect_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`,
     timestamp: Date.now(),
     wasResponded: false

--- a/src/lib/combat/spellExecutor.ts
+++ b/src/lib/combat/spellExecutor.ts
@@ -140,7 +140,8 @@ export function executeMysticPunch(
 export function executeSpellCast(
   state: CombatState,
   isPlayer: boolean,
-  isResolution: boolean = false
+  isResolution: boolean = false,
+  spawnCoord?: AxialCoord
 ): CombatState {
   let newState = { ...state };
   const caster = isPlayer ? 'playerWizard' : 'enemyWizard';
@@ -193,7 +194,7 @@ export function executeSpellCast(
 
   // Apply all spell effects
   for (const effect of selectedSpell.effects) {
-    newState = applySpellEffect(newState, effect, isPlayer);
+    newState = applySpellEffect(newState, effect, isPlayer, spawnCoord);
   }
 
   // Check if combat has ended
@@ -289,7 +290,8 @@ export function getEffectName(effect: SpellEffect): string {
 export function applySpellEffect(
   state: CombatState,
   effect: SpellEffect,
-  isPlayerCaster: boolean
+  isPlayerCaster: boolean,
+  spawnCoord?: AxialCoord
 ): CombatState {
   let newState = { ...state };
   const caster = isPlayerCaster ? 'playerWizard' : 'enemyWizard';
@@ -507,7 +509,7 @@ export function applySpellEffect(
           ...newState.playerMinions.map(m => m.position),
           ...newState.enemyMinions.map(m => m.position),
         ];
-        const spawn = findUnoccupiedAdjacentHex(casterPos, occupied);
+        const spawn = spawnCoord || findUnoccupiedAdjacentHex(casterPos, occupied);
         if (spawn) {
           minion.position = spawn;
           if (owner === 'player') {

--- a/src/lib/types/combat-types.ts
+++ b/src/lib/types/combat-types.ts
@@ -69,6 +69,8 @@ export interface QueuedEffect {
   spell: Spell | null; // null for mystic punch
   spellTier?: number; // for mystic punch
   target: 'player' | 'enemy';
+  /** Optional coordinate for summon effects */
+  spawnCoord?: import('../utils/hexUtils').AxialCoord;
   timestamp: number;
   wasResponded: boolean;
   responseEffect?: QueuedEffect;


### PR DESCRIPTION
## Summary
- track optional `spawnCoord` in queued combat effects
- handle spawn position when resolving summon effects
- calculate selectable summon tiles in `BattleScene`
- let `BattleArena` and `BattleView` forward summon tile selection

## Testing
- `npm test` *(fails: saveModule.test.ts cannot connect)*

------
https://chatgpt.com/codex/tasks/task_e_6845f69de9c88333b841321be727fe67