### PR TITLE
Add move action mode for battles

### DIFF
--- a/src/components/battle/BattleArena.tsx
+++ b/src/components/battle/BattleArena.tsx
@@ -49,6 +49,9 @@ interface BattleArenaProps {
   onMove?: (coord: AxialCoord) => void;
   selectingSummon?: boolean;
   onSummonTile?: (coord: AxialCoord) => void;
+  onStartMove?: () => void;
+  canMove?: boolean;
+  selectingMove?: boolean;
 }
 
 const BattleArena: React.FC<BattleArenaProps> = ({
@@ -86,7 +89,10 @@ const BattleArena: React.FC<BattleArenaProps> = ({
   combatState,
   onMove,
   selectingSummon,
-  onSummonTile
+  onSummonTile,
+  onStartMove,
+  canMove,
+  selectingMove
 }) => {
   // Track if we're on a mobile device
   const [isMobile, setIsMobile] = useState(false);
@@ -166,6 +172,7 @@ const BattleArena: React.FC<BattleArenaProps> = ({
               log={battleLog}
               onMove={onMove}
               selectingSummon={selectingSummon}
+              selectingMove={selectingMove}
               onSummonTile={onSummonTile}
             />
           </div>
@@ -238,6 +245,17 @@ const BattleArena: React.FC<BattleArenaProps> = ({
               }}
             >
               Mystic Punch
+            </button>
+            <button
+              className={styles.mysticPunchButton}
+              onClick={onStartMove}
+              disabled={!canMove}
+              style={{
+                fontSize: window.innerWidth <= 380 ? '0.9rem' : '1rem',
+                padding: window.innerWidth <= 380 ? '0.4rem 0.6rem' : '0.5rem 1rem'
+              }}
+            >
+              {selectingMove ? 'Cancel Move' : 'Move'}
             </button>
             <button
               className={styles.skipTurnButton}
@@ -328,6 +346,7 @@ const BattleArena: React.FC<BattleArenaProps> = ({
               log={battleLog}
               onMove={onMove}
               selectingSummon={selectingSummon}
+              selectingMove={selectingMove}
               onSummonTile={onSummonTile}
             />
           </div>
@@ -368,6 +387,17 @@ const BattleArena: React.FC<BattleArenaProps> = ({
               }}
             >
               Mystic Punch
+            </button>
+            <button
+              className={styles.mysticPunchButton}
+              onClick={onStartMove}
+              disabled={!canMove}
+              style={{
+                fontSize: window.innerWidth <= 380 ? '0.9rem' : '1rem',
+                padding: window.innerWidth <= 380 ? '0.4rem 0.6rem' : '0.5rem 1rem'
+              }}
+            >
+              {selectingMove ? 'Cancel Move' : 'Move'}
             </button>
             <button
               className={styles.skipTurnButton}

--- a/src/components/battle/BattleScene.tsx
+++ b/src/components/battle/BattleScene.tsx
@@ -41,6 +41,7 @@ interface BattleSceneProps {
   currentPhase?: string; // Current combat phase from the phase-based system
   onMove?: (coord: AxialCoord) => void;
   selectingSummon?: boolean;
+  selectingMove?: boolean;
   onSummonTile?: (coord: AxialCoord) => void;
 }
 
@@ -115,13 +116,11 @@ const BattleSceneContent: React.FC<BattleSceneProps> = (props) => {
       setSummonTiles([]);
       return;
     }
+    if (!props.selectingMove) return;
     if (!onMove) return;
     if (!reachableTiles.some(t => t.q === coord.q && t.r === coord.r)) return;
-    setSelectedDest(coord);
-    if (window.confirm('Move here?')) {
-      onMove(coord);
-      setSelectedDest(null);
-    }
+    onMove(coord);
+    setSelectedDest(null);
   };
   
   // Process combat log to create visual effects
@@ -214,7 +213,11 @@ const BattleSceneContent: React.FC<BattleSceneProps> = (props) => {
 
   useEffect(() => {
     if (!combatState) return;
-    if (combatState.currentPhase === 'action' && combatState.isPlayerTurn) {
+    if (
+      combatState.currentPhase === 'action' &&
+      combatState.isPlayerTurn &&
+      props.selectingMove
+    ) {
       const pos = combatState.playerWizard.position;
       const neighbors: AxialCoord[] = [
         { q: pos.q + 1, r: pos.r },
@@ -228,7 +231,12 @@ const BattleSceneContent: React.FC<BattleSceneProps> = (props) => {
     } else {
       setReachableTiles([]);
     }
-  }, [combatState?.currentPhase, combatState?.isPlayerTurn, combatState?.playerWizard.position]);
+  }, [
+    props.selectingMove,
+    combatState?.currentPhase,
+    combatState?.isPlayerTurn,
+    combatState?.playerWizard.position
+  ]);
 
   useEffect(() => {
     if (!combatState || !props.selectingSummon) {
@@ -309,7 +317,13 @@ const BattleSceneContent: React.FC<BattleSceneProps> = (props) => {
           radius={1}
           height={0.2}
           textureMap={textureMap}
-          highlightedTiles={props.selectingSummon ? summonTiles : reachableTiles}
+          highlightedTiles={
+            props.selectingSummon
+              ? summonTiles
+              : props.selectingMove
+                ? reachableTiles
+                : []
+          }
           onTileClick={handleTileClick}
         />
       </group>


### PR DESCRIPTION
## Summary
- add selectable move mode to BattleScene to avoid accidental tile clicks
- provide Move button in BattleArena action list on mobile and desktop
- manage move state in BattleView and clear when invalid

## Testing
- `npm test` *(fails: saveModule and potionModule tests fail due to connection errors)*
- `npm run lint` *(shows many warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845fb8ae23083338867646774f05153