### PR TITLE
Fix Mixamo clip retargeting

### DIFF
--- a/src/hooks/useMixamoClips.ts
+++ b/src/hooks/useMixamoClips.ts
@@ -1,0 +1,46 @@
+import { useFBX } from '@react-three/drei';
+import { useMemo } from 'react';
+import * as THREE from 'three';
+import { SkeletonUtils } from 'three-stdlib';
+
+export interface MixamoActions {
+  idle: string;
+  cast: string;
+  die: string;
+}
+
+function findSkinnedMesh(root: THREE.Object3D | undefined) {
+  let skinned: THREE.SkinnedMesh | undefined;
+  if (!root) return skinned;
+  root.traverse(obj => {
+    if (!skinned && (obj as THREE.SkinnedMesh).isSkinnedMesh) {
+      skinned = obj as THREE.SkinnedMesh;
+    }
+  });
+  return skinned;
+}
+
+export function useMixamoClips(
+  scene: THREE.Object3D | undefined,
+  actions: MixamoActions
+) {
+  const idle = useFBX(actions.idle);
+  const cast = useFBX(actions.cast);
+  const die = useFBX(actions.die);
+
+  return useMemo(() => {
+    const skinned = findSkinnedMesh(scene);
+    if (!skinned) {
+      return {} as Record<keyof MixamoActions, THREE.AnimationClip | undefined>;
+    }
+    const retarget = (fbx: any) =>
+      fbx.animations && fbx.animations[0]
+        ? SkeletonUtils.retargetClip(skinned, fbx, fbx.animations[0])
+        : undefined;
+    return {
+      idle: retarget(idle),
+      cast: retarget(cast),
+      die: retarget(die),
+    } as Record<keyof MixamoActions, THREE.AnimationClip | undefined>;
+  }, [scene, idle, cast, die]);
+}


### PR DESCRIPTION
## Summary
- handle scenes without a root skeleton when retargeting Mixamo clips

## Testing
- `npm run lint` *(fails: various eslint errors)*
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:3000)*

------
https://chatgpt.com/codex/tasks/task_e_6846287d997c833385cffb154989fd04