### PR TITLE
Fix settings persistence on main menu

### DIFF
--- a/src/components/menu/MainMenu.tsx
+++ b/src/components/menu/MainMenu.tsx
@@ -20,7 +20,7 @@ const MainMenu: React.FC<MainMenuProps> = ({
   onStartNewGame,
   onContinueGame
 }) => {
-  const { gameState, updateSettings, migrateSaveData, loadAllSaveSlots, deleteSaveSlot } = useGameStateStore();
+  const { gameState, updateSettings, saveGame, migrateSaveData, loadAllSaveSlots, deleteSaveSlot } = useGameStateStore();
   const { settings, saveSlots } = gameState;
 
   // State for modals
@@ -102,6 +102,8 @@ const MainMenu: React.FC<MainMenuProps> = ({
   const handleSaveSettings = () => {
     console.log('Saving settings:', localSettings);
     updateSettings(localSettings);
+    // Persist settings to storage so they aren't lost when loading a game
+    saveGame();
     setShowSettings(false);
   };
 


### PR DESCRIPTION
## Summary
- ensure settings are saved to storage when changed via `MainMenu`

## Testing
- `npm test` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_684638327b3c83339c729c78bfea5d9c