### PR TITLE
Fix enemy loot dropping spells instead of scrolls

### DIFF
--- a/src/components/battle/BattleView.tsx
+++ b/src/components/battle/BattleView.tsx
@@ -405,7 +405,6 @@ const BattleView: React.FC<BattleViewProps> = ({ onReturnToWizardStudy }) => {
         let lootMessage = "You found: ";
         const foundItems: string[] = [];
         if (lootDrop.gold && lootDrop.gold > 0) foundItems.push(`${lootDrop.gold} gold`);
-        if (lootDrop.spells.length > 0) foundItems.push(...lootDrop.spells.map(s => s.name));
         if (lootDrop.equipment.length > 0) foundItems.push(...lootDrop.equipment.map(e => e.name));
         if (lootDrop.ingredients.length > 0) foundItems.push(...lootDrop.ingredients.map(i => i.name));
         if (lootDrop.scrolls.length > 0) foundItems.push(...lootDrop.scrolls.map(s => s.name));

--- a/src/lib/features/loot/lootSystem.ts
+++ b/src/lib/features/loot/lootSystem.ts
@@ -1,7 +1,5 @@
 // src/lib/features/loot/lootSystem.ts
-import { Wizard, Spell, Equipment, Ingredient, SpellScroll } from '../../types';
-import { getAllSpells, getSpellsByTier } from '../../spells/spellData';
-import { getRandomEquipment } from '../../equipment/equipmentData';
+import { Wizard, Equipment, Ingredient, SpellScroll } from '../../types';
 import { generateProceduralEquipment, generateLootEquipment } from '../procedural/equipmentGenerator';
 import { generateRandomIngredient } from '../procedural/ingredientGenerator';
 import { generateRandomSpellScroll } from '../scrolls/scrollSystem';
@@ -11,7 +9,6 @@ import { calculateWizardStats } from '../../wizard/wizardUtils';
  * Represents a loot drop from defeating an enemy
  */
 export interface LootDrop {
-  spells: Spell[];
   equipment: Equipment[];
   ingredients: Ingredient[];
   scrolls: SpellScroll[];
@@ -33,9 +30,6 @@ export async function generateLoot(
   isWizardEnemy: boolean = true,
   difficulty: 'easy' | 'normal' | 'hard' = 'normal'
 ): Promise<LootDrop> {
-  // Generate spell loot
-  const spells = await generateSpellLoot(playerWizard, enemyWizard, isWizardEnemy, difficulty);
-
   // Generate equipment loot
   const equipment = generateEquipmentLoot(playerWizard, enemyWizard, isWizardEnemy, difficulty);
 
@@ -50,7 +44,6 @@ export async function generateLoot(
   const goldAmount = calculateGoldReward(enemyWizard.level, isWizardEnemy, difficulty);
 
   return {
-    spells,
     equipment,
     ingredients,
     scrolls,
@@ -122,94 +115,6 @@ function calculateGoldReward(
   return Math.floor(baseGold);
 }
 
-/**
- * Generates spell loot after defeating an enemy
- * @param playerWizard The player's wizard
- * @param enemyWizard The defeated enemy wizard
- * @param isWizardEnemy Whether the enemy was a wizard (true) or a magical creature (false)
- * @param difficulty The game difficulty
- * @returns Array of spell loot
- */
-async function generateSpellLoot(
-  playerWizard: Wizard,
-  enemyWizard: Wizard,
-  isWizardEnemy: boolean,
-  difficulty: 'easy' | 'normal' | 'hard'
-): Promise<Spell[]> {
-  const lootSpells: Spell[] = [];
-
-  // Determine number of spells to drop
-  let spellDropCount = 0;
-
-  if (isWizardEnemy) {
-    // Wizards have higher chance to drop spells
-    switch (difficulty) {
-      case 'easy':
-        spellDropCount = Math.floor(Math.random() * 2) + 1; // 1-2 spells
-        break;
-      case 'normal':
-        spellDropCount = Math.random() < 0.7 ? 1 : 0; // 70% chance for 1 spell
-        break;
-      case 'hard':
-        spellDropCount = Math.random() < 0.4 ? 1 : 0; // 40% chance for 1 spell
-        break;
-    }
-
-    // Chance to get one of the enemy's spells
-    if (spellDropCount > 0 && enemyWizard.equippedSpells.length > 0) {
-      const randomEnemySpell = enemyWizard.equippedSpells[
-        Math.floor(Math.random() * enemyWizard.equippedSpells.length)
-      ];
-
-      // Check if player already has this spell
-      if (!playerWizard.spells.some(spell => spell.id === randomEnemySpell.id)) {
-        lootSpells.push(randomEnemySpell);
-        spellDropCount--;
-      }
-    }
-  } else {
-    // Magical creatures have lower chance to drop spells
-    switch (difficulty) {
-      case 'easy':
-        spellDropCount = Math.random() < 0.7 ? 1 : 0; // 70% chance for 1 spell
-        break;
-      case 'normal':
-        spellDropCount = Math.random() < 0.4 ? 1 : 0; // 40% chance for 1 spell
-        break;
-      case 'hard':
-        spellDropCount = Math.random() < 0.2 ? 1 : 0; // 20% chance for 1 spell
-        break;
-    }
-  }
-
-  // Add random spells from appropriate tiers
-  if (spellDropCount > 0) {
-    // Determine max spell tier based on enemy level
-    const maxTier = Math.min(Math.ceil(enemyWizard.level / 3), 10);
-
-    // Get spells from appropriate tiers
-    let availableSpells: Spell[] = [];
-    for (let tier = 1; tier <= maxTier; tier++) {
-      availableSpells = [...availableSpells, ...(await getSpellsByTier(tier))];
-    }
-
-    // Filter out spells the player already has
-    availableSpells = availableSpells.filter(spell =>
-      !playerWizard.spells.some(playerSpell => playerSpell.id === spell.id)
-    );
-
-    // Randomly select spells
-    for (let i = 0; i < spellDropCount; i++) {
-      if (availableSpells.length > 0) {
-        const randomIndex = Math.floor(Math.random() * availableSpells.length);
-        lootSpells.push(availableSpells[randomIndex]);
-        availableSpells.splice(randomIndex, 1);
-      }
-    }
-  }
-
-  return lootSpells;
-}
 
 /**
  * Generates equipment loot after defeating an enemy
@@ -431,13 +336,8 @@ function generateScrollLoot(
 export function applyLoot(playerWizard: Wizard, loot: LootDrop): Wizard {
   console.log("Applying loot to player wizard:", loot);
 
-  // Add spells to wizard's collection (if any)
+  // Player's spells remain unchanged; scrolls allow learning manually
   const updatedSpells = [...playerWizard.spells];
-  for (const spell of loot.spells) {
-    if (!updatedSpells.some(s => s.id === spell.id)) {
-      updatedSpells.push(spell);
-    }
-  }
 
   // Initialize inventory if it doesn't exist
   const updatedInventory = playerWizard.inventory ? [...playerWizard.inventory] : [];


### PR DESCRIPTION
## Summary
- adjust loot drops to only generate spell scrolls
- stop adding spells directly to the player's library on loot

## Testing
- `npm test` *(fails: fetch ECONNREFUSED)*
- `npx tsc -p tsconfig.json --noEmit` *(errors: compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68467157fbe08333bfbb64d017f40c69