### PR TITLE
Add list-based spell loading

### DIFF
--- a/public/data/spell_data.xml
+++ b/public/data/spell_data.xml
@@ -1049,4 +1049,213 @@
     </effects>
     <list>any</list>
   </spell>
+<spell id="spell_summon_undead" name="Summon Undead Minion" type="summon" element="shadow" tier="3" manaCost="30" rarity="rare" imagePath="/images/spells/necromancer-summon.jpg">
+  <description>Summons an undead minion to fight for you.</description>
+  <effects>
+    <effect type="summon" value="1" target="self" element="shadow" duration="3"/>
+  </effects>
+  <list>archetype</list>
+  <list>necromancer</list>
+</spell>
+<spell id="spell_time_rewind" name="Time Rewind" type="buff" element="arcane" tier="3" manaCost="40" rarity="rare" imagePath="/images/spells/timeweaver-rewind.jpg">
+  <description>Rewinds time to undo the last action.</description>
+  <effects>
+    <effect type="buff" value="1" target="self" element="arcane" duration="1"/>
+  </effects>
+  <list>archetype</list>
+  <list>timeWeaver</list>
+</spell>
+<spell id="spell_time_stop" name="Time Stop" type="buff" element="arcane" tier="2" manaCost="30" rarity="uncommon" imagePath="/images/spells/timeweaver-stop.jpg">
+  <description>Freezes time briefly, delaying enemy actions.</description>
+  <effects>
+    <effect type="buff" value="2" target="enemy" element="arcane" duration="1"/>
+  </effects>
+  <list>archetype</list>
+  <list>timeWeaver</list>
+</spell>
+<spell id="spell_temporal_echo" name="Temporal Echo" type="debuff" element="arcane" tier="2" manaCost="25" rarity="uncommon" imagePath="/images/spells/timeweaver-echo.jpg">
+  <description>Creates an echo of your last spell.</description>
+  <effects>
+    <effect type="debuff" value="1" target="self" element="arcane" duration="1"/>
+  </effects>
+  <list>archetype</list>
+  <list>timeWeaver</list>
+</spell>
+<spell id="spell_weapon_enhancement" name="Weapon Enhancement" type="buff" element="earth" tier="2" manaCost="20" rarity="rare" imagePath="/images/spells/battlemage-enhance.jpg">
+  <description>Enhances your weapon with magical power.</description>
+  <effects>
+    <effect type="buff" value="11" target="self" element="earth" duration="3"/>
+  </effects>
+  <list>archetype</list>
+  <list>battleMage</list>
+</spell>
+<spell id="spell_blade_storm" name="Blade Storm" type="attack" element="earth" tier="2" manaCost="25" rarity="uncommon" imagePath="/images/spells/battlemage-storm.jpg">
+  <description>Creates a storm of magical blades.</description>
+  <effects>
+    <effect type="damage" value="6" target="enemy" element="earth"/>
+  </effects>
+  <list>archetype</list>
+  <list>battleMage</list>
+</spell>
+<spell id="spell_combat_surge" name="Combat Surge" type="buff" element="earth" tier="2" manaCost="30" rarity="uncommon" imagePath="/images/spells/battlemage-surge.jpg">
+  <description>Grants temporary combat prowess.</description>
+  <effects>
+    <effect type="buff" value="16" target="self" element="earth" duration="2"/>
+    <effect type="buff" value="6" target="self" element="earth" duration="2"/>
+  </effects>
+  <list>archetype</list>
+  <list>battleMage</list>
+</spell>
+<spell id="spell_mirror_image" name="Mirror Image" type="summon" element="arcane" tier="2" manaCost="25" rarity="rare" imagePath="/images/spells/illusionist-mirror.jpg">
+  <description>Creates illusory copies of yourself.</description>
+  <effects>
+    <effect type="summon" value="2" target="self" element="arcane" duration="3"/>
+  </effects>
+  <list>archetype</list>
+  <list>illusionist</list>
+</spell>
+<spell id="spell_confusion" name="Confusion" type="debuff" element="arcane" tier="2" manaCost="20" rarity="uncommon" imagePath="/images/spells/illusionist-confusion.jpg">
+  <description>Confuses the target, making them attack randomly.</description>
+  <effects>
+    <effect type="debuff" value="1" target="enemy" element="arcane" duration="2"/>
+  </effects>
+  <list>archetype</list>
+  <list>illusionist</list>
+</spell>
+<spell id="spell_phantasmal_force" name="Phantasmal Force" type="attack" element="arcane" tier="2" manaCost="30" rarity="uncommon" imagePath="/images/spells/illusionist-phantasm.jpg">
+  <description>Creates a powerful illusion that causes real damage.</description>
+  <effects>
+    <effect type="damage" value="7" target="enemy" element="arcane"/>
+  </effects>
+  <list>archetype</list>
+  <list>illusionist</list>
+</spell>
+<spell id="spell_potion_throw" name="Potion Throw" type="attack" element="nature" tier="2" manaCost="20" rarity="rare" imagePath="/images/spells/alchemist-potion.jpg">
+  <description>Throws a damaging potion at the enemy.</description>
+  <effects>
+    <effect type="damage" value="17" target="enemy" element="nature" duration="2"/>
+  </effects>
+  <list>archetype</list>
+  <list>alchemist</list>
+</spell>
+<spell id="dragon_breath" name="Dragon Breath" type="attack" element="fire" tier="8" manaCost="60" rarity="rare" imagePath="/images/spells/default-placeholder.jpg">
+  <description>A devastating cone of fire that burns everything in its path.</description>
+  <effects>
+    <effect type="damage" value="80" target="enemy" element="fire"/>
+    <effect type="debuff" value="30" duration="3" target="enemy" element="fire"/>
+  </effects>
+  <list>creature</list>
+  <list>ancientDragon</list>
+</spell>
+<spell id="wing_blast" name="Wing Blast" type="attack" element="air" tier="6" manaCost="40" rarity="uncommon" imagePath="/images/spells/default-placeholder.jpg">
+  <description>A powerful gust of wind created by the dragon's massive wings.</description>
+  <effects>
+    <effect type="damage" value="50" target="enemy" element="air"/>
+  </effects>
+  <list>creature</list>
+  <list>ancientDragon</list>
+</spell>
+<spell id="void_blast" name="Void Blast" type="attack" element="arcane" tier="8" manaCost="70" rarity="rare" imagePath="/images/spells/default-placeholder.jpg">
+  <description>A blast of pure void energy that erases matter from existence.</description>
+  <effects>
+    <effect type="damage" value="90" target="enemy" element="arcane"/>
+    <effect type="debuff" value="30" duration="2" target="enemy" element="arcane"/>
+  </effects>
+  <list>creature</list>
+  <list>eldritchHorror</list>
+</spell>
+<spell id="portal_strike" name="Portal Strike" type="attack" element="arcane" tier="6" manaCost="45" rarity="uncommon" imagePath="/images/spells/default-placeholder.jpg">
+  <description>Creates a portal that strikes the enemy from an unexpected angle.</description>
+  <effects>
+    <effect type="damage" value="60" target="enemy" element="arcane"/>
+  </effects>
+  <list>creature</list>
+  <list>eldritchHorror</list>
+</spell>
+<spell id="growing_vines" name="Growing Vines" type="attack" element="earth" tier="7" manaCost="50" rarity="uncommon" imagePath="/images/spells/default-placeholder.jpg">
+  <description>Summons massive vines that constrict and damage the enemy.</description>
+  <effects>
+    <effect type="damage" value="40" target="enemy" element="earth"/>
+    <effect type="debuff" value="20" duration="3" target="enemy" element="earth"/>
+  </effects>
+  <list>creature</list>
+  <list>natureGuardian</list>
+</spell>
+<spell id="stone_blast" name="Stone Blast" type="attack" element="earth" tier="5" manaCost="35" rarity="uncommon" imagePath="/images/spells/default-placeholder.jpg">
+  <description>Hurls massive boulders at the enemy.</description>
+  <effects>
+    <effect type="damage" value="45" target="enemy" element="earth"/>
+  </effects>
+  <list>creature</list>
+  <list>natureGuardian</list>
+</spell>
+<spell id="lightning_strike" name="Lightning Strike" type="attack" element="air" tier="7" manaCost="55" rarity="uncommon" imagePath="/images/spells/default-placeholder.jpg">
+  <description>A powerful bolt of lightning that can chain between enemies.</description>
+  <effects>
+    <effect type="damage" value="70" target="enemy" element="air"/>
+    <effect type="debuff" value="25" duration="2" target="enemy" element="air"/>
+  </effects>
+  <list>creature</list>
+  <list>stormElemental</list>
+</spell>
+<spell id="wind_slash" name="Wind Slash" type="attack" element="air" tier="5" manaCost="30" rarity="uncommon" imagePath="/images/spells/default-placeholder.jpg">
+  <description>A cutting blast of wind that can strike multiple times.</description>
+  <effects>
+    <effect type="damage" value="40" target="enemy" element="air"/>
+  </effects>
+  <list>creature</list>
+  <list>stormElemental</list>
+</spell>
+<spell id="tidal_wave" name="Tidal Wave" type="attack" element="water" tier="8" manaCost="65" rarity="rare" imagePath="/images/spells/default-placeholder.jpg">
+  <description>A massive wave of water that crashes down on the enemy.</description>
+  <effects>
+    <effect type="damage" value="85" target="enemy" element="water"/>
+    <effect type="debuff" value="35" duration="3" target="enemy" element="water"/>
+  </effects>
+  <list>creature</list>
+  <list>abyssalLeviathan</list>
+</spell>
+<spell id="abyssal_darkness" name="Abyssal Darkness" type="attack" element="shadow" tier="6" manaCost="40" rarity="uncommon" imagePath="/images/spells/default-placeholder.jpg">
+  <description>Creates a sphere of darkness that drains the enemy's strength.</description>
+  <effects>
+    <effect type="damage" value="55" target="enemy" element="shadow"/>
+    <effect type="debuff" value="20" duration="2" target="enemy" element="shadow"/>
+  </effects>
+  <list>creature</list>
+  <list>abyssalLeviathan</list>
+</spell>
+<spell id="spell_acid_splash" name="Acid Splash" type="attack" element="nature" tier="2" manaCost="15" rarity="uncommon" imagePath="/images/spells/alchemist-acid.jpg">
+  <description>Splashes acid on the target, dealing damage over time.</description>
+  <effects>
+    <effect type="damage" value="6" target="enemy" element="nature" duration="2"/>
+  </effects>
+  <list>archetype</list>
+  <list>alchemist</list>
+</spell>
+<spell id="spell_healing_elixir" name="Healing Elixir" type="healing" element="nature" tier="2" manaCost="25" rarity="uncommon" imagePath="/images/spells/alchemist-heal.jpg">
+  <description>Creates a healing elixir that restores health over time.</description>
+  <effects>
+    <effect type="healing" value="7" target="self" element="nature" duration="3"/>
+  </effects>
+  <list>archetype</list>
+  <list>alchemist</list>
+</spell>
+<spell id="spell_death_bolt" name="Death Bolt" type="attack" element="shadow" tier="2" manaCost="20" rarity="uncommon" imagePath="/images/spells/necromancer-bolt.jpg">
+  <description>A bolt of dark energy that saps life force.</description>
+  <effects>
+    <effect type="damage" value="15" target="enemy" element="shadow"/>
+    <effect type="healing" value="5" target="self" element="shadow"/>
+  </effects>
+  <list>archetype</list>
+  <list>necromancer</list>
+</spell>
+<spell id="spell_soul_drain" name="Soul Drain" type="attack" element="shadow" tier="3" manaCost="35" rarity="uncommon" imagePath="/images/spells/necromancer-drain.jpg">
+  <description>Drains the target's soul, dealing damage and healing yourself.</description>
+  <effects>
+    <effect type="damage" value="25" target="enemy" element="shadow"/>
+    <effect type="healing" value="10" target="self" element="shadow"/>
+  </effects>
+  <list>archetype</list>
+  <list>necromancer</list>
+</spell>
 </spells>

--- a/src/components/battle/BattleView.tsx
+++ b/src/components/battle/BattleView.tsx
@@ -169,6 +169,7 @@ const BattleView: React.FC<BattleViewProps> = ({ onReturnToWizardStudy }) => {
 
   // Initialize combat once
   useEffect(() => {
+    const init = async () => {
     if (isInitialized) return;
 
     // Check if we're coming from wizard's study (valid entry point)
@@ -193,7 +194,7 @@ const BattleView: React.FC<BattleViewProps> = ({ onReturnToWizardStudy }) => {
     }
     // console.log("Player wizard for battle:", playerWizard.name, "Level:", playerWizard.level);
     const difficulty = gameState.settings.difficulty as 'easy' | 'normal' | 'hard';
-    const rawEnemy = generateEnemy(playerWizard.level, difficulty);
+    const rawEnemy = await generateEnemy(playerWizard.level, difficulty);
     const enemyWizard = {
       ...rawEnemy,
       modelPath: rawEnemy.modelPath,
@@ -286,6 +287,8 @@ const BattleView: React.FC<BattleViewProps> = ({ onReturnToWizardStudy }) => {
       // Let the InitiativeRoll component generate random values
       setShowInitiativeRoll(true);
     }
+    };
+    init();
   }, []);
 
   // Update battle log when combat state changes

--- a/src/lib/features/procedural/magicalCreatures.ts
+++ b/src/lib/features/procedural/magicalCreatures.ts
@@ -1,4 +1,5 @@
-import { Spell, ElementType, SpellType } from '../../types';
+import { Spell, ElementType } from '../../types';
+import { getSpellsByList } from '../../spells/spellData';
 
 export interface MagicalCreature {
   name: string;
@@ -28,7 +29,7 @@ export interface MagicalCreature {
       element?: ElementType;
     };
   };
-  thematicSpells: Spell[];
+  getThematicSpells: () => Promise<Spell[]>;
   lootTable: {
     common: string[];
     uncommon: string[];
@@ -66,51 +67,7 @@ export const magicalCreatures: Record<string, MagicalCreature> = {
         element: 'fire',
       },
     },
-    thematicSpells: [
-      {
-        id: 'dragon_breath',
-        name: 'Dragon Breath',
-        type: 'attack',
-        element: 'fire',
-        tier: 8,
-        manaCost: 60,
-        description: 'A devastating cone of fire that burns everything in its path.',
-        effects: [
-          {
-            type: 'damage',
-            value: 80,
-            target: 'enemy',
-            element: 'fire',
-          },
-          {
-            type: 'debuff',
-            value: 30,
-            duration: 3,
-            target: 'enemy',
-            element: 'fire',
-          },
-        ],
-        imagePath: '/images/spells/default-placeholder.jpg',
-      },
-      {
-        id: 'wing_blast',
-        name: 'Wing Blast',
-        type: 'attack',
-        element: 'air',
-        tier: 6,
-        manaCost: 40,
-        description: 'A powerful gust of wind created by the dragon\'s massive wings.',
-        effects: [
-          {
-            type: 'damage',
-            value: 50,
-            target: 'enemy',
-            element: 'air',
-          },
-        ],
-        imagePath: '/images/spells/default-placeholder.jpg',
-      },
-    ],
+    getThematicSpells: async () => getSpellsByList('ancientDragon'),
     lootTable: {
       common: ['Dragon Scale', 'Dragon Claw', 'Dragon Fang'],
       uncommon: ['Dragon Wing', 'Dragon Tail', 'Dragon Heart'],
@@ -146,51 +103,7 @@ export const magicalCreatures: Record<string, MagicalCreature> = {
         element: 'arcane',
       },
     },
-    thematicSpells: [
-      {
-        id: 'void_blast',
-        name: 'Void Blast',
-        type: 'attack',
-        element: 'arcane',
-        tier: 8,
-        manaCost: 70,
-        description: 'A blast of pure void energy that erases matter from existence.',
-        effects: [
-          {
-            type: 'damage',
-            value: 90,
-            target: 'enemy',
-            element: 'arcane',
-          },
-          {
-            type: 'debuff',
-            value: 30,
-            duration: 2,
-            target: 'enemy',
-            element: 'arcane',
-          },
-        ],
-        imagePath: '/images/spells/default-placeholder.jpg',
-      },
-      {
-        id: 'portal_strike',
-        name: 'Portal Strike',
-        type: 'attack',
-        element: 'arcane',
-        tier: 6,
-        manaCost: 45,
-        description: 'Creates a portal that strikes the enemy from an unexpected angle.',
-        effects: [
-          {
-            type: 'damage',
-            value: 60,
-            target: 'enemy',
-            element: 'arcane',
-          },
-        ],
-        imagePath: '/images/spells/default-placeholder.jpg',
-      },
-    ],
+    getThematicSpells: async () => getSpellsByList('eldritchHorror'),
     lootTable: {
       common: ['Void Shard', 'Eldritch Fragment', 'Dark Essence'],
       uncommon: ['Void Crystal', 'Eldritch Eye', 'Dark Matter'],
@@ -225,51 +138,7 @@ export const magicalCreatures: Record<string, MagicalCreature> = {
         element: 'earth',
       },
     },
-    thematicSpells: [
-      {
-        id: 'growing_vines',
-        name: 'Growing Vines',
-        type: 'attack',
-        element: 'earth',
-        tier: 7,
-        manaCost: 50,
-        description: 'Summons massive vines that constrict and damage the enemy.',
-        effects: [
-          {
-            type: 'damage',
-            value: 40,
-            target: 'enemy',
-            element: 'earth',
-          },
-          {
-            type: 'debuff',
-            value: 20,
-            duration: 3,
-            target: 'enemy',
-            element: 'earth',
-          },
-        ],
-        imagePath: '/images/spells/default-placeholder.jpg',
-      },
-      {
-        id: 'stone_blast',
-        name: 'Stone Blast',
-        type: 'attack',
-        element: 'earth',
-        tier: 5,
-        manaCost: 35,
-        description: 'Hurls massive boulders at the enemy.',
-        effects: [
-          {
-            type: 'damage',
-            value: 45,
-            target: 'enemy',
-            element: 'earth',
-          },
-        ],
-        imagePath: '/images/spells/default-placeholder.jpg',
-      },
-    ],
+    getThematicSpells: async () => getSpellsByList('natureGuardian'),
     lootTable: {
       common: ['Wood Shard', 'Stone Fragment', 'Leaf Essence'],
       uncommon: ['Ancient Wood', 'Living Stone', 'Forest Essence'],
@@ -304,51 +173,7 @@ export const magicalCreatures: Record<string, MagicalCreature> = {
         element: 'air',
       },
     },
-    thematicSpells: [
-      {
-        id: 'lightning_strike',
-        name: 'Lightning Strike',
-        type: 'attack',
-        element: 'air',
-        tier: 7,
-        manaCost: 55,
-        description: 'A powerful bolt of lightning that can chain between enemies.',
-        effects: [
-          {
-            type: 'damage',
-            value: 70,
-            target: 'enemy',
-            element: 'air',
-          },
-          {
-            type: 'debuff',
-            value: 25,
-            duration: 2,
-            target: 'enemy',
-            element: 'air',
-          },
-        ],
-        imagePath: '/images/spells/default-placeholder.jpg',
-      },
-      {
-        id: 'wind_slash',
-        name: 'Wind Slash',
-        type: 'attack',
-        element: 'air',
-        tier: 5,
-        manaCost: 30,
-        description: 'A cutting blast of wind that can strike multiple times.',
-        effects: [
-          {
-            type: 'damage',
-            value: 40,
-            target: 'enemy',
-            element: 'air',
-          },
-        ],
-        imagePath: '/images/spells/default-placeholder.jpg',
-      },
-    ],
+    getThematicSpells: async () => getSpellsByList('stormElemental'),
     lootTable: {
       common: ['Storm Shard', 'Wind Essence', 'Lightning Fragment'],
       uncommon: ['Storm Crystal', 'Wind Core', 'Lightning Essence'],
@@ -384,58 +209,7 @@ export const magicalCreatures: Record<string, MagicalCreature> = {
         element: 'water',
       },
     },
-    thematicSpells: [
-      {
-        id: 'tidal_wave',
-        name: 'Tidal Wave',
-        type: 'attack',
-        element: 'water',
-        tier: 8,
-        manaCost: 65,
-        description: 'A massive wave of water that crashes down on the enemy.',
-        effects: [
-          {
-            type: 'damage',
-            value: 85,
-            target: 'enemy',
-            element: 'water',
-          },
-          {
-            type: 'debuff',
-            value: 35,
-            duration: 3,
-            target: 'enemy',
-            element: 'water',
-          },
-        ],
-        imagePath: '/images/spells/default-placeholder.jpg',
-      },
-      {
-        id: 'abyssal_darkness',
-        name: 'Abyssal Darkness',
-        type: 'attack',
-        element: 'shadow',
-        tier: 6,
-        manaCost: 40,
-        description: 'Creates a sphere of darkness that drains the enemy\'s strength.',
-        effects: [
-          {
-            type: 'damage',
-            value: 55,
-            target: 'enemy',
-            element: 'shadow',
-          },
-          {
-            type: 'debuff',
-            value: 20,
-            duration: 2,
-            target: 'enemy',
-            element: 'shadow',
-          },
-        ],
-        imagePath: '/images/spells/default-placeholder.jpg',
-      },
-    ],
+    getThematicSpells: async () => getSpellsByList('abyssalLeviathan'),
     lootTable: {
       common: ['Abyssal Shard', 'Ocean Essence', 'Dark Water'],
       uncommon: ['Abyssal Crystal', 'Ocean Core', 'Dark Tide'],
@@ -444,4 +218,4 @@ export const magicalCreatures: Record<string, MagicalCreature> = {
       legendary: ['Abyssal Soul', 'Ocean Spirit', 'Dark Leviathan Heart'],
     },
   },
-}; 
+};

--- a/src/lib/spells/specialSpellData.ts
+++ b/src/lib/spells/specialSpellData.ts
@@ -27,13 +27,7 @@ export async function getAllSpecialSpells(): Promise<Spell[]> {
  */
 export async function getSpellsByList(listType: string): Promise<Spell[]> {
   const spells = await getAllSpells();
-  // If the spell has a 'list' property as an array or string, check for match
-  return spells.filter(spell => {
-    if (Array.isArray((spell as any).list)) {
-      return (spell as any).list.includes(listType);
-    }
-    return (spell as any).list === listType;
-  });
+  return spells.filter(spell => (spell.lists || []).includes(listType));
 }
 
 /**

--- a/src/lib/spells/spellData.ts
+++ b/src/lib/spells/spellData.ts
@@ -54,7 +54,8 @@ function parseXmlSpells(xmlText: string): Spell[] {
           health: e.health !== undefined ? parseInt(e.health, 10) : undefined,
         }));
       }
-      return { id, name, type, element, tier, manaCost, description, effects, imagePath, rarity } as Spell;
+      const lists = node.list ? (Array.isArray(node.list) ? node.list : [node.list]) : ['any'];
+      return { id, name, type, element, tier, manaCost, description, effects, imagePath, rarity, lists } as Spell;
     });
   } else {
     // Client-side: use DOMParser
@@ -81,7 +82,9 @@ function parseXmlSpells(xmlText: string): Spell[] {
         modelPath: e.getAttribute('modelPath') || undefined,
         health: e.hasAttribute('health') ? parseInt(e.getAttribute('health')!, 10) : undefined,
       }));
-      return { id, name, type, element, tier, manaCost, description, effects, imagePath, rarity } as Spell;
+      const lists = Array.from(node.getElementsByTagName('list')).map(n => n.textContent || '').filter(Boolean);
+      if (lists.length === 0) lists.push('any');
+      return { id, name, type, element, tier, manaCost, description, effects, imagePath, rarity, lists } as Spell;
     });
   }
 }
@@ -148,6 +151,16 @@ export async function getSpellsByType(type: SpellType): Promise<Spell[]> {
 export async function getSpellByName(name: string): Promise<Spell | undefined> {
   const spells = await loadSpellsFromXML();
   return spells.find(s => s.name.toLowerCase() === name.toLowerCase());
+}
+
+export async function getSpellById(id: string): Promise<Spell | undefined> {
+  const spells = await loadSpellsFromXML();
+  return spells.find(s => s.id === id);
+}
+
+export async function getSpellsByList(listName: string): Promise<Spell[]> {
+  const spells = await loadSpellsFromXML();
+  return spells.filter(s => (s.lists || []).includes(listName));
 }
 
 export function clearSpellCache() {

--- a/src/lib/types/spell-types.ts
+++ b/src/lib/types/spell-types.ts
@@ -22,7 +22,8 @@ export interface Spell {
   effects: SpellEffect[];
   imagePath: string;
   rarity: 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary';
-  list?: string | string[];
+  /** Names of spell lists this spell belongs to */
+  lists?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- parse `<list>` tags when loading spells and expose `getSpellsByList`
- switch enemy archetypes and creatures to load spells from XML
- make enemy generator and battle view async for spell fetching
- update spell interfaces to support `lists`
- add example archetype spells in XML
- add remaining archetype and creature spells to XML so no spells are lost

## Testing
- `npm test` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684673cecaa08333bc6b19998c9b7206