### PR TITLE
Fix enemy slot mapping and test mystic punch bonuses

### DIFF
--- a/docs/technical_documentation.md
+++ b/docs/technical_documentation.md
@@ -415,6 +415,9 @@ Special handling is implemented for 'finger' slots (rings):
 - The player has two ring slots, `finger1` and `finger2`.
 - When equipping a ring, the system checks for an empty slot. If both are filled, the first slot (`finger1`) is replaced, and the previously equipped ring is returned to inventory.
 - Unequipping a ring requires specifying which slot to remove from.
+- Enemy wizards now use the same slot keys (`hand`, `body`, `neck`, `finger1`,
+  `finger2`) when generated. This ensures their equipment bonuses are included
+  when `calculateWizardStats` is called.
 
 This logic is implemented in both the state management (wizardModule.ts) and the UI (EquipmentScreen.tsx), ensuring robust and consistent behavior.
 

--- a/src/lib/combat/__tests__/mysticPunch.test.ts
+++ b/src/lib/combat/__tests__/mysticPunch.test.ts
@@ -1,0 +1,114 @@
+import { executeMysticPunch } from '../spellExecutor';
+import { calculateWizardStats } from '../../wizard/wizardUtils';
+import { CombatState, Wizard, Equipment } from '../../types';
+
+const dagger: Equipment = {
+  id: 'd1',
+  name: 'Dagger',
+  slot: 'hand',
+  rarity: 'common',
+  bonuses: [
+    { stat: 'mysticPunchPower', value: 10 },
+    { stat: 'bleedEffect', value: 3 },
+  ],
+  description: '',
+  equipped: true,
+  unlocked: true,
+};
+
+function createWizard(withDagger: boolean): Wizard {
+  return calculateWizardStats({
+    id: 'w1',
+    name: 'Test',
+    level: 1,
+    experience: 0,
+    experienceToNextLevel: 100,
+    health: 100,
+    mana: 100,
+    maxHealth: 100,
+    maxMana: 100,
+    manaRegen: 1,
+    spells: [],
+    equippedSpells: [],
+    equipment: withDagger ? { hand: dagger } : {},
+    inventory: [],
+    potions: [],
+    equippedPotions: [],
+    equippedSpellScrolls: [],
+    ingredients: [],
+    discoveredRecipes: [],
+    levelUpPoints: 0,
+    gold: 0,
+    skillPoints: 0,
+    decks: [],
+    activeDeckId: null,
+    combatStats: {},
+    baseMaxHealth: 100,
+    progressionMaxHealth: 0,
+    equipmentMaxHealth: 0,
+    totalMaxHealth: 100,
+    baseMaxMana: 100,
+    progressionMaxMana: 0,
+    equipmentMaxMana: 0,
+    totalMaxMana: 100,
+  } as Wizard);
+}
+
+function createState(player: Wizard, enemy: Wizard): CombatState {
+  return {
+    playerWizard: {
+      wizard: player,
+      currentHealth: player.maxHealth,
+      currentMana: player.maxMana,
+      activeEffects: [],
+      selectedSpell: null,
+      hand: [],
+      drawPile: [],
+      discardPile: [],
+      equippedPotions: [],
+      equippedSpellScrolls: [],
+      position: { q: 0, r: 0 },
+      minions: [],
+    },
+    enemyWizard: {
+      wizard: enemy,
+      currentHealth: enemy.maxHealth,
+      currentMana: enemy.maxMana,
+      activeEffects: [],
+      selectedSpell: null,
+      hand: [],
+      drawPile: [],
+      discardPile: [],
+      equippedPotions: [],
+      equippedSpellScrolls: [],
+      position: { q: 1, r: 0 },
+      minions: [],
+    },
+    playerMinions: [],
+    enemyMinions: [],
+    turn: 1,
+    round: 1,
+    isPlayerTurn: true,
+    log: [],
+    status: 'active',
+    difficulty: 'normal',
+    currentPhase: 'action',
+    firstActor: 'player',
+    initiative: { player: 1, enemy: 1 },
+    actionState: { player: { hasActed: false, hasResponded: false }, enemy: { hasActed: false, hasResponded: false } },
+    effectQueue: [],
+    pendingResponse: { active: false, action: null, respondingActor: null, responseTimeRemaining: 0 },
+  } as CombatState;
+}
+
+test('mystic punch power and bleed effect from equipment apply', () => {
+  const player = createWizard(true);
+  const enemy = createWizard(false);
+  const state = createState(player, enemy);
+
+  const result = executeMysticPunch(state, 1, true);
+
+  expect(result.enemyWizard.currentHealth).toBe(enemy.maxHealth - 20);
+  expect(result.enemyWizard.activeEffects.length).toBe(1);
+  expect(result.enemyWizard.activeEffects[0].value).toBe(3);
+});

--- a/src/lib/features/procedural/enemyGenerator.ts
+++ b/src/lib/features/procedural/enemyGenerator.ts
@@ -173,24 +173,24 @@ function generateRandomWizardName(theme: string): string {
  * Adds equipment to a wizard based on their level and archetype
  */
 function addEquipment(wizard: Wizard, level: number, archetype: any): void {
-  // Add wand with theme-appropriate bonuses
-  wizard.equipment.wand = generateProceduralEquipment(level, 'hand');
-  
+  // Add weapon with theme-appropriate bonuses
+  wizard.equipment.hand = generateProceduralEquipment(level, 'hand');
+
   // Add robe with theme-appropriate bonuses
-  wizard.equipment.robe = generateProceduralEquipment(level, 'body');
-  
+  wizard.equipment.body = generateProceduralEquipment(level, 'body');
+
   // Add amulet if high enough level
   if (level >= 3) {
-    wizard.equipment.amulet = generateProceduralEquipment(level, 'neck');
+    wizard.equipment.neck = generateProceduralEquipment(level, 'neck');
   }
-  
+
   // Add rings if high enough level
   if (level >= 5) {
-    wizard.equipment.ring1 = generateProceduralEquipment(level, 'finger');
+    wizard.equipment.finger1 = generateProceduralEquipment(level, 'finger');
   }
-  
+
   if (level >= 10) {
-    wizard.equipment.ring2 = generateProceduralEquipment(level, 'finger');
+    wizard.equipment.finger2 = generateProceduralEquipment(level, 'finger');
   }
   
   // Add archetype-specific equipment bonuses


### PR DESCRIPTION
## Summary
- fix enemy generator to assign equipment using proper slot keys
- document enemy slot key usage in the technical docs
- add a regression test for mystic punch power and bleed effect calculations

## Testing
- `npm test` *(fails: ETIMEDOUT/ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68468a9e22a48333a1f96dfa18e11673