### PR TITLE
Fix Vercel build error from fs dependency

### DIFF
--- a/src/lib/spells/spellData.ts
+++ b/src/lib/spells/spellData.ts
@@ -1,18 +1,12 @@
 // src/lib/spells/spellData.ts
 import { Spell, SpellEffect, SpellType } from '../types';
 import { ElementType } from '../types/element-types';
-import fs from 'fs/promises';
-import path from 'path';
 
 // XML spell loader utility
 let spellCache: Spell[] = [];
 let spellLoadPromise: Promise<Spell[]> | null = null;
 
 const STRICT_DUPLICATE_CHECK = false; // Set to true to throw on duplicate spell names
-
-function getServerXmlPath() {
-  return path.join(process.cwd(), 'public', 'data', 'spell_data.xml');
-}
 
 function parseAndValidate(xmlText: string): Spell[] {
   const spells: Spell[] = parseXmlSpells(xmlText);
@@ -125,8 +119,10 @@ export async function loadSpellsFromXML(): Promise<Spell[]> {
   const loader = async () => {
     let xmlText: string;
     if (typeof window === 'undefined') {
-      const filePath = getServerXmlPath();
-      xmlText = await fs.readFile(filePath, 'utf8');
+      const { readFile } = await import('fs/promises');
+      const { join } = await import('path');
+      const filePath = join(process.cwd(), 'public', 'data', 'spell_data.xml');
+      xmlText = await readFile(filePath, 'utf8');
     } else {
       const url = getSpellDataUrl();
       const res = await fetch(url);


### PR DESCRIPTION
## Summary
- use dynamic imports for `fs/promises` and `path` in the spell loader

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68469c94a6fc833389b71d1f76269d8c