### PR TITLE
Add difficulty-based rarity and gold scaling

### DIFF
--- a/docs/loot_system_overhaul.md
+++ b/docs/loot_system_overhaul.md
@@ -25,6 +25,10 @@ This document outlines the new approach for post-battle loot generation and the 
    - **Enemy wizards**: higher chance for spell scrolls and equipment pieces.
    - **Magical creatures**: more ingredients and potions, especially ones that fit the creature's theme (blood, venom, scales, etc.).
 5. **Archetype Bias** – Loot tables can weight certain ingredients or items that make sense for the specific archetype or creature type (e.g., fire drakes drop fiery glands).
+6. **Difficulty Influence** –
+   - Easy: highest drop counts and 50% more gold.
+   - Normal: standard loot with a 5% chance for items to upgrade one rarity tier.
+   - Hard: reduced gold to 50% and a 10% chance for items to upgrade one rarity tier.
 
 ## Task List
 
@@ -47,4 +51,8 @@ thresholds mirror market unlock milestones (1–5 common, 5–10 adds uncommon,
 Mappings that bias ingredient generation based on the defeated enemy's
 archetype or creature type. These arrays feed into `generateRandomIngredient`
 to produce thematic drops.
+
+### `maybeUpgradeRarity(rarity, difficulty)`
+Given an item's current rarity and the selected difficulty, this helper adds a small
+chance to increase the rarity by one tier (5% on Normal, 10% on Hard).
 

--- a/src/lib/features/loot/lootSystem.ts
+++ b/src/lib/features/loot/lootSystem.ts
@@ -40,6 +40,20 @@ function getAllowedRarities(level: number): Rarity[] {
   return ['common', 'uncommon', 'rare', 'epic', 'legendary'];
 }
 
+function maybeUpgradeRarity(
+  rarity: Rarity,
+  difficulty: 'easy' | 'normal' | 'hard',
+): Rarity {
+  const currentIndex = rarityTiers.indexOf(rarity);
+  if (currentIndex === rarityTiers.length - 1) return rarity;
+
+  let chance = 0;
+  if (difficulty === 'normal') chance = 0.05;
+  if (difficulty === 'hard') chance = 0.1;
+
+  return Math.random() < chance ? rarityTiers[currentIndex + 1] : rarity;
+}
+
 /**
  * Represents a loot drop from defeating an enemy
  */
@@ -89,13 +103,13 @@ export async function generateLoot(
         ? archetypeIngredientPools[enemyWizard.archetype ?? '']
         : creatureIngredientPools[enemyWizard.archetype ?? ''];
       const allowed = getAllowedRarities(enemyWizard.level);
-      finalIngredients.push(
-        generateRandomIngredient(
-          enemyWizard.level,
-          categories,
-          allowed as IngredientRarity[],
-        ),
+      const fallback = generateRandomIngredient(
+        enemyWizard.level,
+        categories,
+        allowed as IngredientRarity[],
       );
+      fallback.rarity = maybeUpgradeRarity(fallback.rarity as Rarity, difficulty);
+      finalIngredients.push(fallback);
     }
   }
 
@@ -162,10 +176,10 @@ function calculateGoldReward(
   }
   switch (difficulty) {
     case 'easy':
-      baseGold *= 1.2;
+      baseGold *= 1.5;
       break;
     case 'hard':
-      baseGold *= 0.8;
+      baseGold *= 0.5;
       break;
   }
   return Math.floor(baseGold);
@@ -226,11 +240,11 @@ function generateEquipmentLoot(
       const enemyEquipment = Object.values(enemyWizard.equipment).filter(item => item !== undefined);
 
       if (enemyEquipment.length > 0) {
-        const randomEnemyEquipment = enemyEquipment[
+        const randomEnemyEquipment = { ...(enemyEquipment[
           Math.floor(Math.random() * enemyEquipment.length)
-        ];
-
-        lootEquipment.push(randomEnemyEquipment as Equipment);
+        ] as Equipment) };
+        randomEnemyEquipment.rarity = maybeUpgradeRarity(randomEnemyEquipment.rarity as Rarity, difficulty);
+        lootEquipment.push(randomEnemyEquipment);
       }
     } else {
       // Generate procedural equipment based on enemy level
@@ -239,7 +253,11 @@ function generateEquipmentLoot(
 
       // Generate 1-2 equipment pieces for magical creatures
       const equipmentCount = Math.random() < 0.3 ? 2 : 1;
-      lootEquipment.push(...generateLootEquipment(enemyWizard.level, equipmentCount, minRarity));
+      const generated = generateLootEquipment(enemyWizard.level, equipmentCount, minRarity);
+      generated.forEach(eq => {
+        eq.rarity = maybeUpgradeRarity(eq.rarity as Rarity, difficulty);
+      });
+      lootEquipment.push(...generated);
     }
   }
 
@@ -308,13 +326,16 @@ function generateIngredientLoot(
       : creatureIngredientPools[enemyWizard.archetype ?? ''];
     const allowed = getAllowedRarities(enemyWizard.level);
     for (let i = 0; i < ingredientDropCount; i++) {
-      lootIngredients.push(
-        generateRandomIngredient(
-          enemyWizard.level,
-          categories,
-          allowed as IngredientRarity[],
-        ),
+      const ingredient = generateRandomIngredient(
+        enemyWizard.level,
+        categories,
+        allowed as IngredientRarity[],
       );
+      ingredient.rarity = maybeUpgradeRarity(
+        ingredient.rarity as Rarity,
+        difficulty,
+      );
+      lootIngredients.push(ingredient);
     }
   }
 
@@ -372,11 +393,15 @@ async function generateScrollLoot(
   if (Math.random() < scrollDropChance) {
     try {
       // Generate a scroll appropriate for the enemy's level
-      scrolls.push(await generateRandomSpellScroll(enemyWizard.level));
+      const first = await generateRandomSpellScroll(enemyWizard.level);
+      first.rarity = maybeUpgradeRarity(first.rarity as Rarity, difficulty);
+      scrolls.push(first);
 
       // Higher level enemies have a small chance to drop an additional scroll
       if (enemyWizard.level >= 10 && Math.random() < 0.2) {
-        scrolls.push(await generateRandomSpellScroll(enemyWizard.level));
+        const extra = await generateRandomSpellScroll(enemyWizard.level);
+        extra.rarity = maybeUpgradeRarity(extra.rarity as Rarity, difficulty);
+        scrolls.push(extra);
       }
     } catch (err) {
       console.error('Failed to generate scroll loot', err);


### PR DESCRIPTION
## Summary
- introduce `maybeUpgradeRarity` helper and apply it to equipment, ingredients and scrolls
- scale gold reward more for easy and less for hard difficulty
- document new difficulty effects and helper function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846a382389c8333bf2f6c2a9f1d0064