### PR TITLE
Fix animation retarget error

### DIFF
--- a/src/hooks/useMixamoClips.ts
+++ b/src/hooks/useMixamoClips.ts
@@ -39,8 +39,13 @@ export function useMixamoClips(
         return undefined;
       }
 
+      const sourceSkinned = findSkinnedMesh(fbx);
+      if (!sourceSkinned?.skeleton?.bones?.length) {
+        return undefined;
+      }
+
       try {
-        return SkeletonUtils.retargetClip(skinned, fbx, fbx.animations[0]);
+        return SkeletonUtils.retargetClip(skinned, sourceSkinned, fbx.animations[0]);
       } catch (e) {
         console.warn('Failed to retarget clip', e);
         return undefined;


### PR DESCRIPTION
## Summary
- avoid retargeting Mixamo clips if the source FBX lacks a skeleton

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846a61e23d88333ba11e0c52f4de07d