### PR TITLE
Fix animation binding for retargeted models

### DIFF
--- a/src/components/battle/WizardModel.tsx
+++ b/src/components/battle/WizardModel.tsx
@@ -7,7 +7,7 @@ import { VRMLoader } from 'three-stdlib';
 import { Mesh, Vector3 } from 'three';
 import * as THREE from 'three';
 import { getModelRotationForUpAxis, UpAxis } from '@/lib/utils/modelUtils';
-import { useMixamoClips } from '@/hooks/useMixamoClips';
+import { useMixamoClips, findSkinnedMesh } from '@/hooks/useMixamoClips';
 
 interface WizardModelProps {
   position: [number, number, number];
@@ -229,20 +229,24 @@ const WizardModel: React.FC<WizardModelProps> = ({
   // Player: use GLB model
   if (!isEnemy) {
     const { scene } = useGLTF(PLAYER_WIZARD_GLB_PATH);
+    const skinned = useMemo(() => findSkinnedMesh(scene), [scene]);
     const clips = useMixamoClips(scene, {
       idle: '/assets/anims/Idle.fbx',
       cast: '/assets/anims/Standing 1H Cast Spell 01.fbx',
       die: '/assets/anims/Dying.fbx',
     });
-    const mixer = useMemo(() => new THREE.AnimationMixer(scene), [scene]);
+    const mixer = useMemo(
+      () => new THREE.AnimationMixer(skinned || scene),
+      [scene, skinned]
+    );
 
     useEffect(() => {
       const clip = clips[action || 'idle'] || clips.idle;
       if (!clip) return;
-      const act = mixer.clipAction(clip);
+      const act = mixer.clipAction(clip, skinned || undefined);
       act.reset().play();
       return () => act.stop();
-    }, [action, clips, mixer]);
+    }, [action, clips, mixer, skinned]);
 
     useFrame((_, delta) => {
       mixer.update(delta);
@@ -296,20 +300,24 @@ const WizardModel: React.FC<WizardModelProps> = ({
     }
   }
   if (scene) {
+    const skinned = useMemo(() => findSkinnedMesh(scene), [scene]);
     const clips = useMixamoClips(scene, {
       idle: '/assets/anims/Idle.fbx',
       cast: '/assets/anims/Standing 1H Cast Spell 01.fbx',
       die: '/assets/anims/Dying.fbx',
     });
-    const mixer = useMemo(() => new THREE.AnimationMixer(scene), [scene]);
+    const mixer = useMemo(
+      () => new THREE.AnimationMixer(skinned || scene),
+      [scene, skinned]
+    );
 
     useEffect(() => {
       const clip = clips[action || 'idle'] || clips.idle;
       if (!clip) return;
-      const act = mixer.clipAction(clip);
+      const act = mixer.clipAction(clip, skinned || undefined);
       act.reset().play();
       return () => act.stop();
-    }, [action, clips, mixer]);
+    }, [action, clips, mixer, skinned]);
 
     useFrame((_, delta) => {
       mixer.update(delta);

--- a/src/hooks/useMixamoClips.ts
+++ b/src/hooks/useMixamoClips.ts
@@ -9,7 +9,7 @@ export interface MixamoActions {
   die: string;
 }
 
-function findSkinnedMesh(root: THREE.Object3D | undefined) {
+export function findSkinnedMesh(root: THREE.Object3D | undefined) {
   let skinned: THREE.SkinnedMesh | undefined;
   if (!root) return skinned;
   root.traverse(obj => {


### PR DESCRIPTION
## Summary
- export `findSkinnedMesh` helper
- bind animation mixers to the skinned mesh so clips with `bones[]` paths play correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846ae20fc4483338a74fdfd44d3eba4