### PR TITLE
Update spell effects documentation

### DIFF
--- a/docs/spellEffects_review.md
+++ b/docs/spellEffects_review.md
@@ -12,8 +12,8 @@ This document summarizes the current status of each spell effect type available 
 | **healing**          | Yes          | Direct healing                                                                      |
 | **buff**             | Yes          | Healing over time/stat boost                                                        |
 | **debuff**           | Yes          | Damage over time/stat penalty                                                       |
-| **control**          | No           | Not implemented                                                                     |
-| **summon**           | No           | Not implemented                                                                     |
+| **control**          | No           | Planned - will allow taking control of enemy minions |
+| **summon**           | Yes          | Creates minions on the battlefield |
 | **utility**          | No           | Not implemented                                                                     |
 | **timeRewind**       | No           | Not implemented                                                                     |
 | **delay**            | No           | Not implemented                                                                     |
@@ -42,8 +42,8 @@ This document summarizes the current status of each spell effect type available 
 ### Partially Implemented
 - **statModifier**: Used for buffs/debuffs, but not as a standalone effect. In `getEffectName`, it is mapped to "Damage Reduction" or "Power Boost".
 
-### Not Implemented
-- **control, summon, utility, timeRewind, delay, confusion, spellEcho**: No code found that processes or applies these effects.
+-### Not Implemented
+- **control, utility, timeRewind, delay, confusion, spellEcho**: No code found that processes or applies these effects.
 - **damageBonus, defense**: Exist as stats in equipment or AI logic, but not as spell effects in combat.
 
 ---
@@ -84,14 +84,14 @@ Here is a step-by-step review of each spell effect type listed in the dropdown (
 ---
 
 ### 5. **control**
-- **Status:** Not directly implemented.
-- **What it does:** No direct handling found in combat code. May be a placeholder for future effects like stun, silence, etc.
+- **Status:** Not implemented.
+- **What it does:** Planned effect to take control of enemy minions for a duration.
 
 ---
 
 ### 6. **summon**
-- **Status:** Not implemented.
-- **What it does:** No code found that processes or applies a "summon" effect.
+- **Status:** Implemented.
+- **What it does:** Creates minions for the caster or transforms the caster into minions depending on `modelPath`.
 
 ---
 
@@ -169,8 +169,8 @@ Here is a step-by-step review of each spell effect type listed in the dropdown (
 | healing          | Yes          | Direct healing                                                                      |
 | buff             | Yes          | Healing over time/stat boost                                                        |
 | debuff           | Yes          | Damage over time/stat penalty                                                       |
-| control          | No           | Not implemented                                                                     |
-| summon           | No           | Not implemented                                                                     |
+| control          | No           | Planned - will allow taking control of enemy minions |
+| summon           | Yes          | Creates minions on the battlefield |
 | utility          | No           | Not implemented                                                                     |
 | timeRewind       | No           | Not implemented                                                                     |
 | delay            | No           | Not implemented                                                                     |
@@ -186,6 +186,6 @@ Here is a step-by-step review of each spell effect type listed in the dropdown (
 ---
 
 **Conclusion:**  
-Only a subset of the dropdown spell effects are actually hooked up in the combat code. The rest are either placeholders or only referenced in equipment or AI logic, not as spell effects. If you want to add support for any of the unimplemented types, new logic will need to be added to the combat resolution and effect processing code.
+Only a subset of the dropdown spell effects are actually hooked up in the combat code. `summon` is now functional but effects like `control`, `mana_drain`, `stun`, and `silence` remain unimplemented. Adding them will require new logic in `spellExecutor.ts` and `effectsProcessor.ts` as outlined in `docs/spell_effects_refactor_plan.md`.
 
 Let me know if you want a breakdown of how to implement any of the missing effect types, or if you want this summary added to documentation.

--- a/docs/spell_effects_refactor_plan.md
+++ b/docs/spell_effects_refactor_plan.md
@@ -1,0 +1,50 @@
+# Spell Effects Refactor Plan
+
+This document outlines the work required to properly support the currently unused effect types `control`, `mana_drain`, `stun` and `silence`. Implementing these will expand combat variety and fix inconsistencies noted in `spellEffects_review.md`.
+
+## Goals
+- Allow spells to temporarily take control of enemy minions (`control`).
+- Drain mana over time from a target and optionally restore it to the caster (`mana_drain`).
+- Prevent a target from acting (`stun`).
+- Prevent a target from casting spells (`silence`).
+- Maintain clear combat logs and correct effect expiration behaviour.
+
+## Required Changes
+
+1. **Type Updates**
+   - Extend `ActiveEffect['type']` to include `'control'`.
+   - Add optional fields to store affected minion IDs and the original owner so control can be reverted.
+   - Ensure `allowedTypes` in `effectsProcessor.ts` lists all four new effect types.
+
+2. **spellExecutor.ts**
+   - Add a `case 'control'` to change the owner of targeted enemy minions and push a corresponding `ActiveEffect`.
+   - Add cases for `mana_drain`, `stun` and `silence` that create the appropriate `ActiveEffect` with duration and value.
+
+3. **effectsProcessor.ts**
+   - Implement per-turn logic:
+     - `control`: restore minion ownership when the effect expires.
+     - `mana_drain`: reduce target mana each turn and transfer it to the caster if possible.
+     - `stun`: skip the stunned actor's action while active.
+     - `silence`: block spell casting for the affected wizard.
+   - Log each tick and expiration of these effects.
+
+4. **Combat Flow Adjustments**
+   - Phase handlers should respect `stun` and `silence` flags when determining available actions.
+   - AI logic should ignore controlled minions and account for the new effects when selecting spells.
+
+5. **Testing**
+   - Add unit tests to cover application, ticking, and expiration of each effect.
+   - Update existing combat tests to account for the new behaviours.
+
+6. **Documentation**
+   - After implementation, update `docs/spellEffects_review.md` to reflect the supported status of these effects.
+
+## Task Checklist
+- [ ] Update type definitions for `ActiveEffect`.
+- [ ] Implement effect application in `spellExecutor.ts`.
+- [ ] Handle per-turn processing in `effectsProcessor.ts`.
+- [ ] Adjust phase logic and AI behaviour.
+- [ ] Write comprehensive tests.
+- [ ] Update documentation.
+
+


### PR DESCRIPTION
## Summary
- mark `summon` as implemented in spell effects review
- note that `control` is planned
- add a plan document for implementing `control`, `mana_drain`, `stun` and `silence`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6846ab2858248333aea733efb5cef177