### PR TITLE
Fix animation retargeting for wizards

### DIFF
--- a/src/hooks/useMixamoClips.ts
+++ b/src/hooks/useMixamoClips.ts
@@ -45,7 +45,10 @@ export function useMixamoClips(
       }
 
       try {
-        return SkeletonUtils.retargetClip(skinned, sourceSkinned, fbx.animations[0]);
+        return SkeletonUtils.retargetClip(skinned, sourceSkinned, fbx.animations[0], {
+          hip: 'mixamorig:Hips',
+          preservePosition: false,
+        });
       } catch (e) {
         console.warn('Failed to retarget clip', e);
         return undefined;


### PR DESCRIPTION
## Summary
- retarget Mixamo animations with proper options so bones aren't warped

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68471b00a5dc83339cfb3ec3b16d8a52