### PR TITLE
Fix early loot balance for easy difficulty

### DIFF
--- a/src/lib/features/loot/__tests__/lootSystemLowLevel.test.ts
+++ b/src/lib/features/loot/__tests__/lootSystemLowLevel.test.ts
@@ -1,0 +1,48 @@
+import { generateLoot } from '../lootSystem';
+import { calculateWizardStats } from '../../../wizard/wizardUtils';
+import { Wizard } from '../../../types';
+
+function createWizard(level: number): Wizard {
+  return calculateWizardStats({
+    id: `w${level}`,
+    name: 'Test',
+    level,
+    experience: 0,
+    experienceToNextLevel: 100,
+    health: 100,
+    mana: 100,
+    maxHealth: 100,
+    maxMana: 100,
+    manaRegen: 1,
+    spells: [],
+    equippedSpells: [],
+    equipment: {},
+    inventory: [],
+    potions: [],
+    equippedPotions: [],
+    equippedSpellScrolls: [],
+    ingredients: [],
+    discoveredRecipes: [],
+    levelUpPoints: 0,
+    gold: 0,
+    skillPoints: 0,
+    decks: [],
+    activeDeckId: null,
+    combatStats: {},
+    baseMaxHealth: 100,
+    progressionMaxHealth: 0,
+    equipmentMaxHealth: 0,
+    totalMaxHealth: 100,
+    baseMaxMana: 100,
+    progressionMaxMana: 0,
+    equipmentMaxMana: 0,
+    totalMaxMana: 100,
+  } as Wizard);
+}
+
+test('easy difficulty low-level enemies grant extra gold', async () => {
+  const player = createWizard(1);
+  const enemy = createWizard(3);
+  const loot = await generateLoot(player, enemy, true, 'easy');
+  expect(loot.gold).toBe(54);
+});

--- a/src/lib/features/loot/lootSystem.ts
+++ b/src/lib/features/loot/lootSystem.ts
@@ -171,6 +171,12 @@ function calculateGoldReward(
   difficulty: 'easy' | 'normal' | 'hard'
 ): number {
   let baseGold = enemyLevel * 5; // Base gold
+
+  // Boost early-game gold on easy difficulty
+  if (enemyLevel < 5 && difficulty === 'easy') {
+    baseGold *= 2;
+  }
+
   if (isWizardEnemy) {
     baseGold *= 1.2;
   }
@@ -231,6 +237,11 @@ function generateEquipmentLoot(
         equipmentDropChance = 0.3; // 30% chance
         break;
     }
+  }
+
+  // Reduce early-game equipment drops on easy difficulty
+  if (difficulty === 'easy' && enemyWizard.level < 5) {
+    equipmentDropChance *= 0.5;
   }
 
   // Roll for equipment drop
@@ -316,6 +327,12 @@ function generateIngredientLoot(
         ingredientDropCount = Math.floor(Math.random() * 2) + 1; // 1-2 ingredients
         break;
     }
+  }
+
+  // Reduce early-game ingredient drops on easy difficulty
+  if (difficulty === 'easy' && enemyWizard.level < 5) {
+    ingredientDropCount = Math.max(1, Math.floor(ingredientDropCount / 2));
+    ingredientDropChance *= 0.8;
   }
 
   // Roll for ingredient drops


### PR DESCRIPTION
## Summary
- tweak early-game loot: more gold, fewer items on easy mode
- add regression test for gold reward at low levels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68471e5b2af08333a0a7f5710656eca6