### PR TITLE
Fix production build failure on /battle page

### DIFF
--- a/src/app/battle/page.tsx
+++ b/src/app/battle/page.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+// Prevent static pre-rendering since this page relies on browser-only APIs
+export const dynamic = 'force-dynamic';
+
 import React, { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import BattleView from '../../components/battle/BattleView';


### PR DESCRIPTION
## Summary
- mark the Battle page as dynamic so Next.js doesn't pre-render it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68487548b67c8333a82555cdf72f5a21