### PR TITLE
Fix resetState awaiting initial state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2025-06-17
+- **Done: Reset State Fix**
+  - Awaited initial game state generation when resetting
+  - Local storage is fully cleared and slots reinitialize correctly
+
 ## 2025-04-05
 - **Done: Fixed Loot System Gold Application Bug**
   - **Root Cause Fixed**: The `applyLoot` function was missing gold handling, causing loot errors when players tried to collect rewards after winning battles

--- a/src/lib/auth/authService.ts
+++ b/src/lib/auth/authService.ts
@@ -76,7 +76,7 @@ export const authService = {
       
       // Reset the game state store
       const gameStore = useGameStateStore.getState();
-      gameStore.resetState();
+      await gameStore.resetState();
       
       // Load user's game state if it exists
       const savedGameState = await dbService.loadGameState(user.id);
@@ -147,7 +147,7 @@ export const authService = {
     }
     
     // Reset game state to initial values
-    useGameStateStore.getState().resetState();
+    await useGameStateStore.getState().resetState();
   },
   
   /**

--- a/src/lib/game-state/__tests__/saveModule.test.ts
+++ b/src/lib/game-state/__tests__/saveModule.test.ts
@@ -115,3 +115,19 @@ test('save and load different slots without overwriting', async () => {
   expect(stateAfterLoad1.gameState.player?.level).toBe(2);
   expect(stateAfterLoad1.gameState.saveSlots[0].level).toBe(1);
 });
+
+test('resetState clears storage and resets slots', async () => {
+  const store = createTestStore();
+  const actions = store.getState();
+
+  await actions.initializeNewGame('Alice', 0);
+  expect(global.localStorage.length).toBeGreaterThan(0);
+
+  await actions.resetState();
+
+  const state = store.getState().gameState;
+  expect(global.localStorage.length).toBe(0);
+  expect(state.saveSlots.length).toBe(3);
+  expect(state.saveSlots.every((s) => s.isEmpty)).toBe(true);
+  expect(state.currentSaveSlot).toBe(state.saveSlots[0].saveUuid);
+});

--- a/src/lib/game-state/clearSaveGames.ts
+++ b/src/lib/game-state/clearSaveGames.ts
@@ -1,7 +1,7 @@
 // Function to clear save games from local storage
 import { useGameStateStore } from './gameStateStore';
 
-export const clearSaveGames = () => {
+export const clearSaveGames = async () => {
   console.log('Clearing all save games...');
 
   try {
@@ -26,7 +26,7 @@ export const clearSaveGames = () => {
     localStorage.removeItem('wizardsChoice_gameState');
 
     // Reset the store state last
-    resetState();
+    await resetState();
 
     console.log('All save data has been cleared');
     return true;

--- a/src/lib/game-state/modules/saveModule.ts
+++ b/src/lib/game-state/modules/saveModule.ts
@@ -17,7 +17,7 @@ export interface SaveActions {
   saveGame: () => void;
   loadGame: (saveUuid: string) => boolean;
   initializeNewGame: (playerName: string, slotId: number) => Promise<void>;
-  resetState: () => void;
+  resetState: () => Promise<void>;
   updateSaveSlot: (saveUuid: string, data: Partial<SaveSlot>) => void;
   deleteSaveSlot: (saveUuid: string) => void;
   getSaveSlots: () => SaveSlot[];
@@ -590,9 +590,9 @@ export const createSaveModule = (set: Function, get: Function): SaveActions => (
     }
   },
 
-  resetState: () => {
+  resetState: async () => {
     // Reset to a default state with empty save slots
-    const initialGameState = getInitialGameState('', 0);
+    const initialGameState = await getInitialGameState('', 0);
 
     // Reset all save slots to empty with new UUIDs
     initialGameState.saveSlots = Array(3).fill(null).map((_, i) => ({
@@ -609,23 +609,8 @@ export const createSaveModule = (set: Function, get: Function): SaveActions => (
 
     // Clear all localStorage entries for save slots
     try {
-      // Clear Zustand persisted store
-      localStorage.removeItem('wizards-choice-game-state');
-
-      // Clear individual save slots (old format)
-      for (let i = 0; i < 3; i++) {
-        localStorage.removeItem(`wizardsChoice_saveSlot_${i}`);
-      }
-
-      // Clear any save slots in new format
-      // This is a simplification - in a real app, we might need to enumerate all keys
-      const allKeys = Object.keys(localStorage);
-      const saveKeys = allKeys.filter(key => key.startsWith('wizardsChoice_save_'));
-      saveKeys.forEach(key => localStorage.removeItem(key));
-
-      // Clear any other game-related data
-      localStorage.removeItem('wizardsChoice_currentSaveSlot');
-      localStorage.removeItem('wizardsChoice_gameState');
+      // Remove everything related to the game
+      localStorage.clear();
 
       console.log('All save data has been cleared from localStorage');
     } catch (error) {


### PR DESCRIPTION
## Summary
- await the asynchronous `getInitialGameState` when resetting
- clear local storage using `localStorage.clear()`
- update authService and clearSaveGames to await `resetState`
- add test for reset functionality
- log change in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850ba217d1083339d798514f7f585d1