### PR TITLE
Fix uninitialized variable in WizardModel

### DIFF
--- a/src/components/battle/WizardModel.tsx
+++ b/src/components/battle/WizardModel.tsx
@@ -245,8 +245,8 @@ const WizardModel: React.FC<WizardModelProps> = ({
     const skinned = useMemo(() => findSkinnedMesh(scene), [scene]);
     const clips = useMixamoClips(scene, descriptor.animations);
     const mixer = useMemo(
-      () => new THREE.AnimationMixer(skinned || sceneObj),
-      [sceneObj, skinned]
+      () => new THREE.AnimationMixer(skinned || scene),
+      [scene, skinned]
     );
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- fix usage of undefined `sceneObj` in WizardModel by referencing `scene`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68510c2211448333b670be63852b095a